### PR TITLE
feat: Support YOLO multi-task types (detect, pose, segment, obb)

### DIFF
--- a/atc-model-converter/SKILL.md
+++ b/atc-model-converter/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: atc-model-converter
-description: Complete toolkit for Huawei Ascend NPU model conversion and inference. (1) Convert ONNX models to .om format using ATC tool with multi-CANN version support (8.3.RC1, 8.5.0+). (2) Run Python inference on OM models using ais_bench. (3) Compare precision between CPU ONNX and NPU OM outputs. (4) End-to-end YOLO inference with Ultralytics preprocessing/postprocessing. Use when converting, testing, or deploying models on Ascend AI processors.
+description: Complete toolkit for Huawei Ascend NPU model conversion and inference. (1) Convert ONNX models to .om format using ATC tool with multi-CANN version support (8.3.RC1, 8.5.0+). (2) Run Python inference on OM models using ais_bench. (3) Compare precision between CPU ONNX and NPU OM outputs. (4) End-to-end YOLO inference with Ultralytics preprocessing/postprocessing - supports Detection, Pose, Segmentation, OBB tasks. Use when converting, testing, or deploying models on Ascend AI processors.
 ---
 
 # ATC Model Converter
@@ -8,6 +8,8 @@ description: Complete toolkit for Huawei Ascend NPU model conversion and inferen
 Complete guide for converting ONNX models to Ascend AI processor compatible format using ATC (Ascend Tensor Compiler) tool.
 
 **Supported CANN Versions:** 8.3.RC1, 8.5.0
+
+---
 
 ## ⚠️ Critical Compatibility Requirements
 
@@ -31,7 +33,25 @@ pip install "numpy<2.0" --force-reinstall
 pip install decorator attrs absl-py psutil protobuf sympy
 ```
 
-See [FAQ.md](references/FAQ.md) for detailed troubleshooting.
+---
+
+## ⚠️ IMPORTANT: SoC Version Must Match Exactly
+
+> **SoC version in ATC conversion must exactly match your target device!**
+> 
+> ```bash
+> # Get exact SoC version from your device
+> npu-smi info | grep Name
+> # Output: Name: 910B3 → Use: --soc_version=Ascend910B3
+> # Output: Name: 310P3 → Use: --soc_version=Ascend310P3
+> ```
+> 
+> **Common Error:**
+> ```
+> [ACL ERROR] EE1001: supported socVersion=Ascend910B3, 
+> but the model socVersion=Ascend910B
+> ```
+> **Fix:** Use exact SoC version from `npu-smi info`, not generic version!
 
 ---
 
@@ -39,200 +59,90 @@ See [FAQ.md](references/FAQ.md) for detailed troubleshooting.
 
 ```bash
 # 1. Check your CANN version and environment
-./scripts/check_env.sh
+./scripts/check_env_enhanced.sh
 
-# 2. Source the appropriate environment (see CANN Version Guide below)
-export PATH=/home/miniconda3/envs/atc_py310/bin:$PATH  # If using conda
-export PYTHONPATH=/home/miniconda3/envs/atc_py310/lib/python3.10/site-packages:$PYTHONPATH
+# 2. Source the appropriate environment
 source /usr/local/Ascend/ascend-toolkit/set_env.sh  # For 8.1.RC1/8.3.RC1
 # OR
-source /usr/local/Ascend/cann/set_env.sh  # For 8.5.0
+source /usr/local/Ascend/cann/set_env.sh            # For 8.5.0+
 
 # 3. Basic ONNX to OM conversion
-atc --model=model.onnx --framework=5 --output=output_model --soc_version=Ascend310P3
+atc --model=model.onnx --framework=5 --output=output_model \
+    --soc_version=Ascend910B3
 
 # With input shape specification
 atc --model=model.onnx --framework=5 --output=output_model \
-    --soc_version=Ascend310P3 \
-    --input_shape="input:1,3,224,224"
-
-# With AIPP preprocessing
-atc --model=model.onnx --framework=5 --output=output_model \
-    --soc_version=Ascend310P3 \
-    --insert_op_conf=aipp_config.cfg
-```
-
-## CANN Version Guide
-
-Different CANN versions have different environment setup paths:
-
-| CANN Version | Environment Path | Ops Package Requirement |
-|--------------|------------------|-------------------------|
-| 8.3.RC1 | `/usr/local/Ascend/ascend-toolkit/set_env.sh` | Standard installation |
-| 8.5.0 | `/usr/local/Ascend/cann/set_env.sh` | Must install matching ops package |
-
-### Auto-detect CANN Version
-
-```bash
-# Use provided script to detect and set environment
-./scripts/setup_env.sh
-
-# Or manually check version
-atc --help 2>&1 | head -5
-# OR
-cat /usr/local/Ascend/ascend-toolkit/latest/version.cfg 2>/dev/null || \
-cat /usr/local/Ascend/cann/latest/version.cfg 2>/dev/null
-```
-
-### Environment Setup by Version
-
-**For CANN 8.3.RC1:**
-```bash
-source /usr/local/Ascend/ascend-toolkit/set_env.sh
-export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/lib64:$LD_LIBRARY_PATH
-```
-
-**For CANN 8.5.0+:**
-```bash
-source /usr/local/Ascend/cann/set_env.sh
-# For non-Ascend host development only:
-export LD_LIBRARY_PATH=/usr/local/Ascend/cann/<arch>-linux/devlib:$LD_LIBRARY_PATH
-```
-
-## OM Model Inference
-
-After converting your model to OM format, use ais_bench for Python inference on Ascend NPU.
-
-### Install ais_bench
-
-**Option 1: Download pre-built wheel packages (recommended)**
-
-```bash
-# Download from Huawei OBS (choose version matching your Python and architecture)
-# See: https://gitee.com/ascend/tools/blob/master/ais-bench_workload/tool/ais_bench/README.md
-
-# Example for Python 3.10, aarch64:
-wget https://aisbench.obs.myhuaweicloud.com/packet/ais_bench_infer/0.0.2/ait/aclruntime-0.0.2-cp310-cp310-linux_aarch64.whl
-wget https://aisbench.obs.myhuaweicloud.com/packet/ais_bench_infer/0.0.2/ait/ais_bench-0.0.2-py3-none-any.whl
-
-# Install
-pip3 install ./aclruntime-*.whl ./ais_bench-*.whl
-```
-
-**Option 2: Build from source (if pre-built packages unavailable)**
-
-```bash
-git clone https://gitee.com/ascend/tools.git
-cd tools/ais-bench_workload/tool/ais_bench
-
-# Build packages
-pip3 wheel ./backend/ -v  # Build aclruntime
-pip3 wheel ./ -v          # Build ais_bench
-
-# Install
-pip3 install ./aclruntime-*.whl ./ais_bench-*.whl
-```
-
-### Basic Inference
-
-```bash
-# Print model info
-python3 scripts/infer_om.py --model model.om --info
-
-# Run inference with random input
-python3 scripts/infer_om.py --model model.om --input-shape "1,3,640,640"
-
-# Run inference with actual input
-python3 scripts/infer_om.py --model model.om --input test.npy --output result.npy
-
-# Performance benchmark
-python3 scripts/infer_om.py --model model.om --warmup 10 --loop 100
-```
-
-### Python API Usage
-
-```python
-from ais_bench.infer.interface import InferSession
-import numpy as np
-
-# Initialize session
-session = InferSession(device_id=0, model_path="model.om")
-
-# Get model info
-print("Inputs:", [(i.name, i.shape) for i in session.get_inputs()])
-print("Outputs:", [(o.name, o.shape) for o in session.get_outputs()])
-
-# Run inference
-input_data = np.random.randn(1, 3, 640, 640).astype(np.float32)
-outputs = session.infer([input_data], mode='static')
-
-# Get timing
-print(f"Inference time: {session.summary().exec_time_list[-1]:.3f} ms")
-
-# Cleanup
-session.free_resource()
+    --soc_version=Ascend910B3 \
+    --input_shape="input:1,3,640,640"
 ```
 
 ---
 
-## Precision Comparison
+## YOLO Model Conversion & Inference
 
-Verify conversion accuracy by comparing ONNX (CPU) vs OM (NPU) outputs.
+### YOLO Task Types & Output Formats
 
-```bash
-# Basic comparison
-python3 scripts/compare_precision.py --onnx model.onnx --om model.om --input test.npy
+| Task | Model Example | ONNX Output | Post-processing |
+|------|---------------|-------------|-----------------|
+| **Detection** | yolo26n.pt | `(1, 84, 8400)` | decode + NMS |
+| **Pose** | yolo26n-pose.pt | `(1, 300, 57)` | filter only |
+| **Segmentation** | yolo26n-seg.pt | `(1, 116, 8400)` | decode + NMS + mask |
+| **OBB** | yolo26n-obb.pt | `(1, 15, 8400)` | decode + NMS |
 
-# With custom tolerances
-python3 scripts/compare_precision.py --onnx model.onnx --om model.om --input test.npy \
-    --atol 1e-3 --rtol 1e-2
+> **Note:** YOLO ONNX outputs are raw feature maps, not processed detections. The `yolo_om_infer.py` script handles decode + NMS automatically.
 
-# Save detailed results
-python3 scripts/compare_precision.py --onnx model.onnx --om model.om --input test.npy \
-    --output comparison.json --save-diff ./diff/
-```
-
-### Understanding Results
-
-| Metric | Description |
-|--------|-------------|
-| `cosine_similarity` | 1.0 = identical, >0.99 = very close |
-| `max_abs_diff` | Maximum absolute difference |
-| `outlier_ratio` | Percentage of values exceeding tolerance |
-| `is_close` | Pass/fail based on atol/rtol |
-
-**Typical acceptable thresholds:**
-- FP32 models: `atol=1e-4`, `rtol=1e-3`
-- FP16 models: `atol=1e-3`, `rtol=1e-2`
-
----
-
-## End-to-End YOLO Inference
-
-Run complete YOLO inference pipeline with Ultralytics preprocessing/postprocessing.
-
-```bash
-# Single image
-python3 scripts/yolo_om_infer.py --model yolo.om --source image.jpg --output result.jpg
-
-# Directory of images
-python3 scripts/yolo_om_infer.py --model yolo.om --source images/ --output results/
-
-# With custom confidence threshold
-python3 scripts/yolo_om_infer.py --model yolo.om --source image.jpg --conf 0.5
-
-# Save detection results to txt files
-python3 scripts/yolo_om_infer.py --model yolo.om --source images/ --save-txt
-```
-
-### Python API for YOLO
+### Step 1: Export YOLO to ONNX
 
 ```python
-from yolo_om_infer import YoloOMInferencer
+from ultralytics import YOLO
 
-# Initialize
+model = YOLO('yolo26n.pt')  # or yolo26n-pose.pt, yolo26n-seg.pt, etc.
+
+# Export with opset 11 for CANN 8.1.RC1 compatibility
+model.export(format='onnx', imgsz=640, opset=11, simplify=True)
+```
+
+### Step 2: Convert to OM
+
+```bash
+# Get your SoC version first
+npu-smi info | grep Name
+
+# Convert
+atc --model=yolo26n.onnx --framework=5 --output=yolo26n \
+    --soc_version=Ascend910B3 \
+    --input_shape="images:1,3,640,640"
+```
+
+### Step 3: Run Inference
+
+```bash
+# Detection (default)
+python3 scripts/yolo_om_infer.py --model yolo26n.om \
+    --source image.jpg --task detect --output result.jpg
+
+# Pose estimation
+python3 scripts/yolo_om_infer.py --model yolo26n-pose.om \
+    --source image.jpg --task pose --output result_pose.jpg
+
+# Segmentation
+python3 scripts/yolo_om_infer.py --model yolo26n-seg.om \
+    --source image.jpg --task segment --output result_seg.jpg
+
+# Oriented Bounding Box
+python3 scripts/yolo_om_infer.py --model yolo26n-obb.om \
+    --source image.jpg --task obb --output result_obb.jpg
+```
+
+### YOLO Python API
+
+```python
+from yolo_om_infer import YoloOMInferencer, draw_results
+
+# Initialize for detection
 inferencer = YoloOMInferencer(
-    model_path="yolo.om",
+    model_path="yolo26n.om",
+    task="detect",  # or "pose", "segment", "obb"
     device_id=0,
     conf_thres=0.25,
     iou_thres=0.45
@@ -252,42 +162,95 @@ for det in result['detections']:
 inferencer.free_resource()
 ```
 
+For detailed YOLO guide, see [YOLO_GUIDE.md](references/YOLO_GUIDE.md).
+
 ---
 
-## Prerequisites
+## OM Model Inference (General)
 
-### Required Software
+After converting your model to OM format, use ais_bench for Python inference.
 
-- CANN Toolkit (8.3.RC1 or 8.5.0)
-- Python 3.7+ (for helper scripts)
-- onnxruntime (optional, for `get_onnx_info.py`)
-
-### Environment Variables
+### Install ais_bench
 
 ```bash
-# Optional: Set parallel compilation for large models
-export TE_PARALLEL_COMPILER=8
+# Download pre-built wheel packages (recommended)
+# See: https://gitee.com/ascend/tools/blob/master/ais-bench_workload/tool/ais_bench/README.md
 
-# Optional: Enable graph dump for debugging
-export DUMP_GE_GRAPH=1
+# Example for Python 3.10, aarch64:
+wget https://aisbench.obs.myhuaweicloud.com/packet/ais_bench_infer/0.0.2/ait/aclruntime-0.0.2-cp310-cp310-linux_aarch64.whl
+wget https://aisbench.obs.myhuaweicloud.com/packet/ais_bench_infer/0.0.2/ait/ais_bench-0.0.2-py3-none-any.whl
 
-# Optional: Enable verbose logging
-export ASCEND_SLOG_PRINT_TO_STDOUT=1
+pip3 install ./aclruntime-*.whl ./ais_bench-*.whl
 ```
 
-### Verify Environment
+### Basic Inference
 
 ```bash
-# Check ATC tool is available
-which atc
-atc --help | head -3
+# Print model info
+python3 scripts/infer_om.py --model model.om --info
 
-# Check NPU device info
-npu-smi info -l
+# Run inference with random input
+python3 scripts/infer_om.py --model model.om --input-shape "1,3,640,640"
 
-# Verify CANN environment
-echo $ASCEND_HOME
+# Run inference with actual input
+python3 scripts/infer_om.py --model model.om --input test.npy --output result.npy
 ```
+
+### Python API
+
+```python
+from ais_bench.infer.interface import InferSession
+import numpy as np
+
+session = InferSession(device_id=0, model_path="model.om")
+print("Inputs:", [(i.name, i.shape) for i in session.get_inputs()])
+print("Outputs:", [(o.name, o.shape) for o in session.get_outputs()])
+
+input_data = np.random.randn(1, 3, 640, 640).astype(np.float32)
+outputs = session.infer([input_data], mode='static')
+
+print(f"Inference time: {session.summary().exec_time_list[-1]:.3f} ms")
+session.free_resource()
+```
+
+See [INFERENCE.md](references/INFERENCE.md) for detailed ais_bench usage.
+
+---
+
+## Precision Comparison
+
+Verify conversion accuracy by comparing ONNX (CPU) vs OM (NPU) outputs.
+
+```bash
+# Basic comparison
+python3 scripts/compare_precision.py --onnx model.onnx --om model.om --input test.npy
+
+# With custom tolerances
+python3 scripts/compare_precision.py --onnx model.onnx --om model.om --input test.npy \
+    --atol 1e-3 --rtol 1e-2
+```
+
+| Metric | Description | Good Value |
+|--------|-------------|------------|
+| `cosine_similarity` | 1.0 = identical | >0.99 |
+| `max_abs_diff` | Maximum absolute difference | <1e-3 (FP32) |
+| `is_close` | Pass/fail based on atol/rtol | True |
+
+---
+
+## CANN Version Guide
+
+| CANN Version | Environment Path | Notes |
+|--------------|------------------|-------|
+| 8.3.RC1 | `/usr/local/Ascend/ascend-toolkit/set_env.sh` | Standard installation |
+| 8.5.0+ | `/usr/local/Ascend/cann/set_env.sh` | Must install matching ops package |
+
+```bash
+# Auto-detect CANN version
+./scripts/setup_env.sh
+```
+
+---
 
 ## Core Parameters
 
@@ -296,171 +259,31 @@ echo $ASCEND_HOME
 | `--model` | Yes | Input ONNX model path | `--model=resnet50.onnx` |
 | `--framework` | Yes | Framework type (5=ONNX) | `--framework=5` |
 | `--output` | Yes | Output OM model path | `--output=resnet50` |
-| `--soc_version` | Yes | Ascend chip version | `--soc_version=Ascend310P3` |
+| `--soc_version` | Yes | **Must match device exactly** | `--soc_version=Ascend910B3` |
 | `--input_shape` | Optional | Input tensor shapes | `--input_shape="input:1,3,224,224"` |
-| `--input_format` | Optional | Input format (NCHW/NHWC) | `--input_format=NCHW` |
 | `--precision_mode` | Optional | Precision mode | `--precision_mode=force_fp16` |
-| `--insert_op_conf` | Optional | AIPP config file path | `--insert_op_conf=aipp.cfg` |
-| `--log` | Optional | Log level | `--log=info` |
 
-## Common Workflows
-
-### 0. Preparing ONNX Model (CRITICAL)
-
-Before ATC conversion, ensure your ONNX model uses the correct opset version:
-
-**Using Ultralytics (YOLO models):**
-```python
-from ultralytics import YOLO
-
-model = YOLO('model.pt')
-# Use opset 11 for maximum compatibility with CANN 8.1.RC1
-model.export(format='onnx', imgsz=640, opset=11)
-```
-
-**Using PyTorch directly:**
-```python
-import torch
-
-dummy_input = torch.randn(1, 3, 640, 640)
-torch.onnx.export(
-    model,
-    dummy_input,
-    'model.onnx',
-    opset_version=11,  # Use 11 for CANN 8.1.RC1, 13 or 17 for newer CANN
-    input_names=['images'],
-    output_names=['output0']
-)
-```
-
-**Verify ONNX opset version:**
-```bash
-# Install onnx if needed
-pip install onnx
-
-# Check opset version
-python3 -c "import onnx; model = onnx.load('model.onnx'); print(model.opset_import)"
-```
+For complete parameters, see [PARAMETERS.md](references/PARAMETERS.md).
 
 ---
 
-### 1. Basic ONNX Conversion
+## SoC Version Reference
 
-Convert a simple ONNX model without shape specification:
-
-```bash
-atc --model=yolov5s.onnx \
-    --framework=5 \
-    --output=yolov5s \
-    --soc_version=Ascend310P3
-```
-
-### 2. Conversion with Input Shape
-
-When input shape is dynamic or needs override:
-
-```bash
-# First, inspect ONNX input names
-python3 scripts/get_onnx_info.py model.onnx
-
-# Then convert with correct input name
-atc --model=model.onnx \
-    --framework=5 \
-    --output=model_om \
-    --soc_version=Ascend310P3 \
-    --input_shape="actual_input_name:1,3,640,640"
-```
-
-### 3. Conversion with AIPP
-
-AIPP (AI Preprocessing) handles image preprocessing on NPU:
-
-```bash
-# Create AIPP config file
-cat > aipp.cfg << 'AIPP_EOF'
-aipp_op {
-    aipp_mode: static
-    input_format: YUV420SP_U8
-    src_image_size_w: 640
-    src_image_size_h: 640
-    crop: false
-    resize: false
-    csc_switch: true
-    matrix_r0c0: 298
-    matrix_r0c1: 516
-    matrix_r0c2: 0
-    matrix_r1c0: 298
-    matrix_r1c1: -100
-    matrix_r1c2: -208
-    matrix_r2c0: 298
-    matrix_r2c1: 0
-    matrix_r2c2: 409
-    input_bias_0: 16
-    input_bias_1: 128
-    input_bias_2: 128
-    mean_chn_0: 104
-    mean_chn_1: 117
-    mean_chn_2: 123
-    min_chn_0: 0.0
-    min_chn_1: 0.0
-    min_chn_2: 0.0
-    var_reci_chn_0: 1.0
-    var_reci_chn_1: 1.0
-    var_reci_chn_2: 1.0
-}
-AIPP_EOF
-
-# Convert with AIPP
-atc --model=model.onnx \
-    --framework=5 \
-    --output=model_aipp \
-    --soc_version=Ascend310P3 \
-    --insert_op_conf=aipp.cfg
-```
-
-### 4. Precision Mode Selection
-
-Control computation precision:
-
-```bash
-# Force FP32 for maximum precision
-atc --model=model.onnx --framework=5 --output=model_fp32 \
-    --soc_version=Ascend310P3 --precision_mode=force_fp32
-
-# Force FP16 for better performance (may reduce precision)
-atc --model=model.onnx --framework=5 --output=model_fp16 \
-    --soc_version=Ascend310P3 --precision_mode=force_fp16
-
-# Allow mix precision (default)
-atc --model=model.onnx --framework=5 --output=model_mix \
-    --soc_version=Ascend310P3 --precision_mode=allow_mix_precision
-```
-
-## Soc Version Reference
-
-| Device | Soc Version | How to Check |
+| Device | SoC Version | How to Check |
 |--------|-------------|--------------|
-| Atlas 200I DK A2 | Ascend310B4 | `npu-smi info` |
-| Atlas 310P | Ascend310P1/P3 | `npu-smi info` |
-| Atlas 910 | Ascend910 | `npu-smi info` |
-| Atlas 910B | Ascend910B | `npu-smi info` |
+| Atlas 910B3 | Ascend910B3 | `npu-smi info \| grep Name` |
+| Atlas 310P | Ascend310P1/P3 | `npu-smi info \| grep Name` |
+| Atlas 200I DK A2 | Ascend310B4 | `npu-smi info \| grep Name` |
 
-**Get your soc_version:**
-```bash
-# Get Name field, prepend "Ascend"
-npu-smi info | grep Name
-# Result: Name: xxxyy → Use: Ascendxxxyy
-```
+**Always verify with `npu-smi info` - do not assume version!**
+
+---
 
 ## Troubleshooting
 
 ### Error: Opname not found in model
-
-**Cause:** Wrong input name specified in `--input_shape`
-
-**Solution:**
 ```bash
-# Verify input names with script
+# Verify input names
 python3 scripts/get_onnx_info.py model.onnx
 
 # Use correct name in conversion
@@ -468,80 +291,45 @@ atc --model=model.onnx --input_shape="correct_name:1,3,224,224" ...
 ```
 
 ### Error: Invalid soc_version
-
-**Cause:** Wrong chip version specified
-
-**Solution:**
 ```bash
-# Check actual chip version
-npu-smi info
-# Use the exact Name from output with "Ascend" prefix
+# Check actual chip version - must be EXACT match
+npu-smi info | grep Name
+# Use: Ascend + Name value (e.g., Ascend910B3, not Ascend910B)
 ```
 
 ### Conversion Too Slow
-
-**Solution:** Enable parallel compilation
 ```bash
 export TE_PARALLEL_COMPILER=16
 atc --model=model.onnx ...
 ```
 
-### Debug Graph Issues
+### YOLO Detection Results Look Wrong
+- Ensure you're using correct `--task` parameter
+- Detection models need decode + NMS (script handles this)
+- Pose models output top-300 detections (no NMS needed)
 
-```bash
-# Enable graph dumping
-export DUMP_GE_GRAPH=2
-export DUMP_GRAPH_LEVEL=2
+See [FAQ.md](references/FAQ.md) for more troubleshooting.
 
-# Run conversion, then check generated .pbtxt files
-atc --model=model.onnx ...
-# View ge_onnx*.pbtxt with Netron
-```
-
-## Version-Specific Notes
-
-### CANN 8.3.RC1
-
-- Environment path: `/usr/local/Ascend/ascend-toolkit/`
-- Some advanced fusion options may differ
-- Standard ops package installation
-
-### CANN 8.5.0+
-
-- Environment path: `/usr/local/Ascend/cann/`
-- **Important:** Must install matching ops package for target device
-- Enhanced fusion and optimization capabilities
-- New parameters: `--compression_optimize_conf`, `--op_compiler_cache_mode`
-
-See [CANN_VERSIONS.md](references/CANN_VERSIONS.md) for detailed version-specific differences.
-
-## Advanced Parameters
-
-See [PARAMETERS.md](references/PARAMETERS.md) for complete ATC parameter reference including:
-- Fusion configuration
-- Custom operator settings
-- Dynamic shape handling
-- Quantization options
-- Memory optimization
+---
 
 ## Resources
 
 ### scripts/
 **Conversion & Environment:**
-- **`check_env_enhanced.sh`** - ⭐ **RECOMMENDED** - Comprehensive compatibility check (Python, NumPy, modules, CANN)
+- **`check_env_enhanced.sh`** - ⭐ Comprehensive compatibility check
 - `get_onnx_info.py` - Inspect ONNX model inputs/outputs
+- `setup_env.sh` - Auto-setup CANN environment with SoC warning
 - `convert_onnx.sh` - Batch conversion helper
-- `check_env.sh` - Basic CANN environment check
-- `setup_env.sh` - Auto-setup CANN environment
 
 **Inference & Testing:**
+- **`yolo_om_infer.py`** - ⭐ End-to-end YOLO inference (detect/pose/segment/obb)
 - **`infer_om.py`** - ⭐ Python inference for OM models using ais_bench
 - **`compare_precision.py`** - ⭐ Compare ONNX vs OM output precision
-- **`yolo_om_infer.py`** - ⭐ End-to-end YOLO inference with Ultralytics pipeline
 
 ### references/
+- **[YOLO_GUIDE.md](references/YOLO_GUIDE.md)** - ⭐ YOLO detailed guide (formats, post-processing)
 - [PARAMETERS.md](references/PARAMETERS.md) - Complete ATC parameter reference
 - [AIPP_CONFIG.md](references/AIPP_CONFIG.md) - AIPP configuration guide
-- [INFERENCE.md](references/INFERENCE.md) - ⭐ ais_bench inference guide (API, modes, optimization)
+- [INFERENCE.md](references/INFERENCE.md) - ais_bench inference guide
 - [FAQ.md](references/FAQ.md) - Frequently asked questions
 - [CANN_VERSIONS.md](references/CANN_VERSIONS.md) - Version-specific guidance

--- a/atc-model-converter/references/YOLO_GUIDE.md
+++ b/atc-model-converter/references/YOLO_GUIDE.md
@@ -1,0 +1,341 @@
+# YOLO Model Guide for Ascend NPU
+
+Detailed guide for converting and running YOLO models on Huawei Ascend NPU.
+
+---
+
+## Supported YOLO Versions & Tasks
+
+| Version | Detection | Pose | Segmentation | OBB | Classification |
+|---------|-----------|------|--------------|-----|----------------|
+| YOLOv5 | ✅ | - | ✅ | - | - |
+| YOLOv8 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| YOLO11 | ✅ | ✅ | ✅ | ✅ | ✅ |
+| YOLO26 | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+> **Note:** This guide focuses on detection, pose, segmentation, and OBB tasks. Classification is a simple forward pass.
+
+---
+
+## YOLO Output Format Reference
+
+Understanding YOLO ONNX output formats is critical for correct post-processing.
+
+### Detection Output
+
+**Shape:** `(1, 84, 8400)` for YOLOv8/v11/YOLO26 with 80 COCO classes
+
+**Format:**
+- 84 channels = 4 (box) + 80 (class scores)
+- 8400 anchors = (640/8)² + (640/16)² + (640/32)² = 64 + 256 + 1024 = 1344 (for 640 input)
+
+**Layout:**
+```
+output[0, 0:4, :]    → Box coordinates (cx, cy, w, h) for each anchor
+output[0, 4:84, :]   → Class scores for each anchor
+```
+
+**Post-processing Steps:**
+1. Transpose to `(8400, 84)`
+2. Extract boxes: `predictions[:, :4]` (cx, cy, w, h)
+3. Extract class scores: `predictions[:, 4:]`
+4. Get best class: `scores = class_scores.max(axis=1)`
+5. Filter by confidence threshold
+6. Convert boxes to xyxy format
+7. Apply NMS (Non-Maximum Suppression)
+
+### Pose Output
+
+**Shape:** `(1, 300, 57)` for COCO 17 keypoints
+
+**Format:**
+- 300 = top-k detections (already sorted by confidence)
+- 57 = 4 (box) + 1 (box conf) + 1 (class) + 51 (17 keypoints × 3)
+
+**Layout:**
+```
+output[0, :, 0:4]    → Box coordinates (x1, y1, x2, y2) - already in corner format
+output[0, :, 4]      → Box confidence
+output[0, :, 5]      → Class score (always 0 for person)
+output[0, :, 6:57]   → Keypoints: (x, y, conf) × 17
+```
+
+**Post-processing Steps:**
+1. Filter by confidence (no NMS needed - already top-k)
+2. Parse keypoints: reshape `output[:, 6:]` to `(N, 17, 3)`
+3. Scale boxes and keypoints to original image size
+
+**COCO Keypoints (17):**
+```
+0: nose        5: left_shoulder   9: left_wrist    13: left_ankle
+1: left_eye    6: right_shoulder  10: right_wrist  14: right_ankle
+2: right_eye   7: left_elbow      11: left_hip     15: left_knee
+3: left_ear    8: right_elbow     12: right_hip    16: right_knee
+4: right_ear
+```
+
+### Segmentation Output
+
+**Shape:** `(1, 116, 8400)` for 80 classes + 32 mask coefficients
+
+**Format:**
+- 116 = 4 (box) + 80 (class) + 32 (mask coefficients)
+- Two outputs possible: (detection_output, mask_protos)
+
+**Layout:**
+```
+output[0, 0:4, :]     → Box coordinates (cx, cy, w, h)
+output[0, 4:84, :]    → Class scores
+output[0, 84:116, :]  → Mask coefficients (32 values per anchor)
+```
+
+**Post-processing Steps:**
+1. Same as detection for boxes
+2. Extract mask coefficients
+3. If mask_protos available, compute masks: `masks = sigmoid(mask_protos @ mask_coeffs.T)`
+
+### OBB (Oriented Bounding Box) Output
+
+**Shape:** `(1, 15, 8400)` for DOTA 15 classes
+
+**Format:**
+- 15 = 4 (box) + 1 (angle) + 10 (class scores) or similar
+
+**Layout:**
+```
+output[0, 0:4, :]    → Box coordinates (cx, cy, w, h)
+output[0, 4, :]      → Rotation angle in radians
+output[0, 5:15, :]   → Class scores
+```
+
+**Post-processing Steps:**
+1. Same as detection for filtering
+2. Keep angle information with boxes
+3. Draw rotated rectangles using angle
+
+---
+
+## Post-Processing Code Examples
+
+### Detection Post-Processing
+
+```python
+import numpy as np
+
+def postprocess_detect(output, conf_thres=0.25, iou_thres=0.45):
+    """
+    Post-process YOLO detection output.
+    
+    Args:
+        output: Model output of shape (1, 84, 8400)
+        conf_thres: Confidence threshold
+        iou_thres: IoU threshold for NMS
+    
+    Returns:
+        boxes_xyxy: (N, 4) array of boxes in xyxy format
+        scores: (N,) array of confidence scores
+        class_ids: (N,) array of class indices
+    """
+    # Transpose to (num_anchors, 4+classes)
+    predictions = output[0].T  # (8400, 84)
+    
+    # Extract boxes and class scores
+    boxes_cxcywh = predictions[:, :4]  # cx, cy, w, h
+    class_scores = predictions[:, 4:]
+    
+    # Get best class for each anchor
+    scores = class_scores.max(axis=1)
+    class_ids = class_scores.argmax(axis=1)
+    
+    # Filter by confidence
+    mask = scores >= conf_thres
+    boxes_cxcywh = boxes_cxcywh[mask]
+    scores = scores[mask]
+    class_ids = class_ids[mask]
+    
+    if len(boxes_cxcywh) == 0:
+        return np.array([]), np.array([]), np.array([])
+    
+    # Convert cx, cy, w, h to x1, y1, x2, y2
+    boxes_xyxy = np.zeros_like(boxes_cxcywh)
+    boxes_xyxy[:, 0] = boxes_cxcywh[:, 0] - boxes_cxcywh[:, 2] / 2  # x1
+    boxes_xyxy[:, 1] = boxes_cxcywh[:, 1] - boxes_cxcywh[:, 3] / 2  # y1
+    boxes_xyxy[:, 2] = boxes_cxcywh[:, 0] + boxes_cxcywh[:, 2] / 2  # x2
+    boxes_xyxy[:, 3] = boxes_cxcywh[:, 1] + boxes_cxcywh[:, 3] / 2  # y2
+    
+    # Apply NMS
+    keep = nms_numpy(boxes_xyxy, scores, iou_thres)
+    
+    return boxes_xyxy[keep], scores[keep], class_ids[keep]
+
+def nms_numpy(boxes, scores, iou_threshold):
+    """Non-Maximum Suppression using NumPy."""
+    if len(boxes) == 0:
+        return np.array([], dtype=np.int64)
+    
+    x1, y1, x2, y2 = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    areas = (x2 - x1) * (y2 - y1)
+    order = scores.argsort()[::-1]
+    
+    keep = []
+    while order.size > 0:
+        i = order[0]
+        keep.append(i)
+        
+        # Calculate IoU
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+        
+        w = np.maximum(0.0, xx2 - xx1)
+        h = np.maximum(0.0, yy2 - yy1)
+        inter = w * h
+        
+        iou = inter / (areas[i] + areas[order[1:]] - inter + 1e-6)
+        inds = np.where(iou <= iou_threshold)[0]
+        order = order[inds + 1]
+    
+    return np.array(keep, dtype=np.int64)
+```
+
+### Pose Post-Processing
+
+```python
+def postprocess_pose(output, conf_thres=0.25, num_keypoints=17):
+    """
+    Post-process YOLO pose output.
+    
+    Args:
+        output: Model output of shape (1, 300, 57)
+        conf_thres: Confidence threshold
+        num_keypoints: Number of keypoints (17 for COCO)
+    
+    Returns:
+        boxes: (N, 4) array in xyxy format
+        scores: (N,) confidence scores
+        keypoints: (N, 17, 3) array of (x, y, conf) per keypoint
+    """
+    predictions = output[0]  # (300, 57)
+    
+    # Parse output
+    boxes = predictions[:, :4]  # Already xyxy
+    box_conf = predictions[:, 4]
+    class_scores = predictions[:, 5]
+    keypoints_flat = predictions[:, 6:]
+    
+    # Combined score
+    scores = box_conf * class_scores
+    
+    # Filter by confidence
+    mask = scores >= conf_thres
+    boxes = boxes[mask]
+    scores = scores[mask]
+    keypoints_flat = keypoints_flat[mask]
+    
+    # Reshape keypoints to (N, 17, 3)
+    keypoints = keypoints_flat.reshape(-1, num_keypoints, 3)
+    
+    return boxes, scores, keypoints
+```
+
+---
+
+## Common Issues and Solutions
+
+### Issue: Confidence > 1.0 for Pose Model
+
+**Symptom:** Detection confidence shows values like 58.16
+
+**Cause:** Using detection post-processing on pose output
+
+**Solution:** Pose output format is different. Use `--task pose` flag:
+```bash
+python3 scripts/yolo_om_infer.py --model yolo-pose.om --source image.jpg --task pose
+```
+
+### Issue: No Detections Found
+
+**Possible causes:**
+1. Confidence threshold too high - try `--conf 0.1`
+2. Wrong task type - verify model type and use correct `--task`
+3. SoC version mismatch - check `npu-smi info` matches `--soc_version`
+
+### Issue: Boxes Not Aligned with Objects
+
+**Cause:** Letterbox padding not removed correctly
+
+**Solution:** Ensure post-processing removes padding offset:
+```python
+# Calculate padding (letterbox centers image)
+pad_h = (input_height - original_height * ratio) / 2
+pad_w = (input_width - original_width * ratio) / 2
+
+# Remove padding and scale
+x1 = (x1 - pad_w) / ratio
+y1 = (y1 - pad_h) / ratio
+x2 = (x2 - pad_w) / ratio
+y2 = (y2 - pad_h) / ratio
+```
+
+### Issue: ONNX Opset Version Error
+
+**Symptom:** `RuntimeError: unsupported operator: ...`
+
+**Solution:** Export with opset 11 for CANN 8.1.RC1:
+```python
+model.export(format='onnx', imgsz=640, opset=11)
+```
+
+---
+
+## Performance Tips
+
+### 1. Use FP16 Precision
+
+```bash
+atc --model=yolo.onnx --framework=5 --output=yolo_fp16 \
+    --soc_version=Ascend910B3 \
+    --precision_mode=force_fp16
+```
+
+### 2. Enable Parallel Compilation
+
+```bash
+export TE_PARALLEL_COMPILER=16
+atc --model=yolo.onnx ...
+```
+
+### 3. Batch Processing
+
+For batch inference, modify input shape:
+```bash
+atc --model=yolo.onnx --framework=5 --output=yolo_batch4 \
+    --soc_version=Ascend910B3 \
+    --input_shape="images:4,3,640,640"
+```
+
+### 4. AIPP for On-Device Preprocessing
+
+Use AIPP to offload preprocessing to NPU:
+```bash
+atc --model=yolo.onnx --framework=5 --output=yolo_aipp \
+    --soc_version=Ascend910B3 \
+    --insert_op_conf=aipp.cfg
+```
+
+See [AIPP_CONFIG.md](AIPP_CONFIG.md) for AIPP configuration details.
+
+---
+
+## Verification Checklist
+
+Before deploying YOLO models, verify:
+
+- [ ] SoC version matches exactly (`npu-smi info` → `--soc_version`)
+- [ ] ONNX opset version is compatible (11 for CANN 8.1.RC1)
+- [ ] Python version is 3.7-3.10
+- [ ] NumPy version is < 2.0
+- [ ] Using correct `--task` parameter for model type
+- [ ] Confidence threshold is appropriate (default 0.25)
+- [ ] Test with sample images before deployment

--- a/atc-model-converter/scripts/setup_env.sh
+++ b/atc-model-converter/scripts/setup_env.sh
@@ -1,9 +1,26 @@
 #!/bin/bash
 # Auto-detect and setup CANN environment
 # Usage: source ./setup_env.sh OR ./setup_env.sh
+#
+# This script will:
+#   1. Detect your CANN installation (8.3.RC1 or 8.5.0+)
+#   2. Source the appropriate environment
+#   3. Verify atc command is available
+#   4. Display SoC version warning
 
-echo "=== ATC Environment Auto-Setup ==="
+set -e
+
+echo "=============================================="
+echo "  ATC Environment Auto-Setup"
+echo "=============================================="
 echo
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
 
 # Detect CANN version and path
 detect_cann_version() {
@@ -26,9 +43,37 @@ detect_cann_version() {
         elif [[ "$atc_path" == *"ascend-toolkit"* ]]; then
             cann_path="/usr/local/Ascend/ascend-toolkit"
         fi
+        cann_version="detected via atc"
     fi
     
     echo "$cann_path|$cann_version"
+}
+
+# Check NPU device and get SoC version
+check_npu_device() {
+    echo -e "\n${BLUE}[NPU Device Check]${NC}"
+    
+    if command -v npu-smi &>/dev/null; then
+        local npu_info=$(npu-smi info 2>/dev/null | grep -E "Name|Version" | head -5)
+        if [ -n "$npu_info" ]; then
+            echo "$npu_info"
+            
+            # Extract SoC name
+            local soc_name=$(npu-smi info 2>/dev/null | grep "Name" | awk '{print $NF}')
+            if [ -n "$soc_name" ]; then
+                echo -e "\n${YELLOW}⚠️  IMPORTANT: SoC Version Matching${NC}"
+                echo "   Your device SoC: Ascend$soc_name"
+                echo "   ATC command must use: --soc_version=Ascend$soc_name"
+                echo -e "   ${RED}Error example: supported socVersion=Ascend910B3, but the model socVersion=Ascend910B${NC}"
+                echo
+            fi
+        else
+            echo -e "${YELLOW}Warning: npu-smi info returned empty${NC}"
+        fi
+    else
+        echo -e "${YELLOW}npu-smi not found - running on non-Ascend host?${NC}"
+        echo "For conversion on non-Ascend host, ensure you know the target device's SoC version."
+    fi
 }
 
 # Setup environment based on version
@@ -38,44 +83,59 @@ setup_environment() {
     local cann_version=$(echo "$result" | cut -d'|' -f2)
     
     if [ -z "$cann_path" ]; then
-        echo "✗ CANN installation not found!"
-        echo "  Please install CANN Toolkit first."
+        echo -e "${RED}✗ CANN installation not found!${NC}"
+        echo
+        echo "Please install CANN Toolkit first:"
+        echo "  Download from: https://www.hiascend.com/software/cann"
+        echo
         return 1
     fi
     
-    echo "✓ CANN installation found:"
+    echo -e "${GREEN}✓ CANN installation found:${NC}"
     echo "  Path: $cann_path"
     echo "  Version: ${cann_version:-Unknown}"
     echo
     
     # Source the environment
     if [ -f "$cann_path/set_env.sh" ]; then
-        echo "→ Sourcing environment from: $cann_path/set_env.sh"
+        echo -e "${BLUE}→ Sourcing environment from: $cann_path/set_env.sh${NC}"
         source "$cann_path/set_env.sh"
-        echo "✓ Environment setup complete"
     else
-        echo "✗ Environment setup script not found at: $cann_path/set_env.sh"
+        echo -e "${RED}✗ Environment setup script not found at: $cann_path/set_env.sh${NC}"
+        return 1
+    fi
+    
+    # Verify atc is available
+    echo
+    echo -e "${BLUE}[ATC Verification]${NC}"
+    if command -v atc &>/dev/null; then
+        local atc_version=$(atc --help 2>&1 | head -1 || echo "unknown")
+        echo -e "${GREEN}✓ atc command available${NC}"
+        echo "  Version info: $atc_version"
+    else
+        echo -e "${RED}✗ atc command not found after sourcing environment!${NC}"
+        echo "  This may indicate an incomplete CANN installation."
         return 1
     fi
     
     # Version-specific additional setup
     if [[ "$cann_path" == *"cann"* ]] && [[ "$cann_version" =~ ^8\.[5-9] ]]; then
         echo
-        echo "ℹ CANN 8.5.0+ detected. Additional setup:"
+        echo -e "${BLUE}[CANN 8.5.0+ Additional Setup]${NC}"
         
         # Check for ops package requirement
         if [ ! -d "$cann_path/opp" ]; then
-            echo "  ⚠ Warning: Ops package (opp) not found!"
+            echo -e "${YELLOW}  ⚠ Warning: Ops package (opp) not found!${NC}"
             echo "    For CANN 8.5.0+, you must install the matching ops package."
         else
-            echo "  ✓ Ops package found"
+            echo -e "${GREEN}  ✓ Ops package found${NC}"
         fi
         
         # Set LD_LIBRARY_PATH for non-Ascend hosts
         if ! command -v npu-smi &>/dev/null; then
             local arch=$(uname -m)
             export LD_LIBRARY_PATH="$cann_path/${arch}-linux/devlib:$LD_LIBRARY_PATH"
-            echo "  ✓ Set LD_LIBRARY_PATH for non-Ascend host development"
+            echo -e "${GREEN}  ✓ Set LD_LIBRARY_PATH for non-Ascend host development${NC}"
         fi
     fi
     
@@ -85,13 +145,21 @@ setup_environment() {
 # Print usage
 print_usage() {
     echo "Usage:"
-    echo "  source $0    # To setup environment in current shell"
+    echo "  source $0    # To setup environment in current shell (recommended)"
     echo "  $0           # To check environment without modifying current shell"
+    echo
+    echo "Options:"
+    echo "  -h, --help   Show this help message"
     echo
     echo "This script will:"
     echo "  1. Detect your CANN installation (8.3.RC1 or 8.5.0+)"
     echo "  2. Source the appropriate environment"
-    echo "  3. Perform version-specific setup"
+    echo "  3. Verify atc command is available"
+    echo "  4. Display NPU device info and SoC version warning"
+    echo
+    echo "Example:"
+    echo "  source ./setup_env.sh"
+    echo "  atc --model=model.onnx --framework=5 --output=model --soc_version=Ascend910B3"
 }
 
 # Main
@@ -102,11 +170,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         exit 0
     fi
     
-    echo "Note: Running script directly. Environment changes will not persist."
+    echo -e "${YELLOW}Note: Running script directly. Environment changes will not persist.${NC}"
     echo "For persistent changes, run: source $0"
     echo
-    setup_environment
+    setup_environment && check_npu_device
 else
     # Script is being sourced
-    setup_environment
+    setup_environment && check_npu_device
 fi

--- a/atc-model-converter/scripts/yolo_om_infer.py
+++ b/atc-model-converter/scripts/yolo_om_infer.py
@@ -3,17 +3,20 @@
 YOLO End-to-End OM Inference Script
 
 Provides Ultralytics-like inference interface for YOLO OM models on Ascend NPU.
-Uses Ultralytics preprocessing (LetterBox) and postprocessing.
+Supports multiple YOLO task types: Detection, Pose, Segmentation, OBB.
 
 Usage:
-    # Single image inference
-    python3 yolo_om_infer.py --model yolo.om --source image.jpg --output result.jpg
+    # Detection task (default)
+    python3 yolo_om_infer.py --model yolo.om --source image.jpg --task detect
 
-    # Multiple images
-    python3 yolo_om_infer.py --model yolo.om --source images/ --output results/
+    # Pose estimation
+    python3 yolo_om_infer.py --model yolo-pose.om --source image.jpg --task pose
 
-    # With custom confidence threshold
-    python3 yolo_om_infer.py --model yolo.om --source image.jpg --conf 0.5
+    # Segmentation
+    python3 yolo_om_infer.py --model yolo-seg.om --source image.jpg --task segment
+
+    # Oriented Bounding Box
+    python3 yolo_om_infer.py --model yolo-obb.om --source image.jpg --task obb
 
 Requirements:
     - ais_bench and aclruntime packages
@@ -27,6 +30,7 @@ import sys
 import time
 import numpy as np
 from pathlib import Path
+from typing import Dict, List, Tuple, Optional, Union
 
 try:
     import cv2
@@ -59,7 +63,14 @@ except ImportError:
     torchvision_nms = None
 
 
-def nms_numpy(boxes, scores, iou_threshold):
+# =============================================================================
+# NMS and Box Utilities
+# =============================================================================
+
+
+def nms_numpy(
+    boxes: np.ndarray, scores: np.ndarray, iou_threshold: float
+) -> np.ndarray:
     """
     Non-Maximum Suppression (NMS) using pure NumPy.
 
@@ -103,278 +114,449 @@ def nms_numpy(boxes, scores, iou_threshold):
     return np.array(keep, dtype=np.int64)
 
 
-class YoloOMInferencer:
+def cxcywh_to_xyxy(boxes: np.ndarray) -> np.ndarray:
+    """Convert boxes from [cx, cy, w, h] to [x1, y1, x2, y2] format."""
+    cx, cy, w, h = boxes[:, 0], boxes[:, 1], boxes[:, 2], boxes[:, 3]
+    x1 = cx - w / 2
+    y1 = cy - h / 2
+    x2 = cx + w / 2
+    y2 = cy + h / 2
+    return np.stack([x1, y1, x2, y2], axis=1)
+
+
+def nms_boxes(boxes: np.ndarray, scores: np.ndarray, iou_thres: float) -> np.ndarray:
+    """Apply NMS using torchvision if available, else numpy."""
+    if len(boxes) == 0:
+        return np.array([], dtype=np.int64)
+
+    if torch is not None and torchvision_nms is not None:
+        return torchvision_nms(
+            torch.from_numpy(boxes.copy()),
+            torch.from_numpy(scores.copy()),
+            iou_thres,
+        ).numpy()
+    else:
+        return nms_numpy(boxes, scores, iou_thres)
+
+
+# =============================================================================
+# Post-processing for Different YOLO Tasks
+# =============================================================================
+
+
+def postprocess_detect(
+    output: np.ndarray,
+    conf_thres: float = 0.25,
+    iou_thres: float = 0.45,
+    num_classes: int = 80,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
-    YOLO OM Model Inferencer using Ultralytics preprocessing.
+    Postprocess YOLO Detection output.
 
-    Provides end-to-end inference with proper letterbox scaling.
+    Supports two output formats:
+    1. Raw format: (1, 4+num_classes, num_anchors) e.g., (1, 84, 8400)
+       - Need transpose and decode + NMS
+    2. Processed format: (1, num_detections, 6) e.g., (1, 300, 6)
+       - Already decoded with NMS, format: [x1, y1, x2, y2, conf, cls]
+
+    Output: boxes_xyxy, scores, class_ids
     """
+    # Handle output format
+    if isinstance(output, (list, tuple)):
+        output = output[0]
 
-    def __init__(
-        self, model_path, device_id=0, imgsz=640, conf_thres=0.25, iou_thres=0.45
-    ):
-        """
-        Initialize YOLO OM inferencer.
-
-        Args:
-            model_path: Path to OM model file
-            device_id: NPU device ID
-            imgsz: Input image size (default 640)
-            conf_thres: Confidence threshold for NMS
-            iou_thres: IoU threshold for NMS
-        """
-        self.model_path = model_path
-        self.device_id = device_id
-        self.imgsz = imgsz
-        self.conf_thres = conf_thres
-        self.iou_thres = iou_thres
-
-        # Load OM model
-        print(f"Loading OM model: {model_path}")
-        self.session = InferSession(device_id=device_id, model_path=model_path)
-
-        # Get model info
-        self.input_info = self.session.get_inputs()[0]
-        self.input_shape = self.input_info.shape
-
-        if len(self.input_shape) == 4:
-            self.batch_size = self.input_shape[0] if self.input_shape[0] > 0 else 1
-            self.input_height = self.input_shape[2]
-            self.input_width = self.input_shape[3]
+    # Determine output format based on shape
+    if output.ndim == 3:
+        # Shape: (1, C, N) where C could be 84 (raw) or N could be 300 (processed)
+        if output.shape[2] == 6:
+            # Processed format: (1, 300, 6) - already decoded
+            predictions = output[0]  # (300, 6)
+        elif output.shape[2] == 7:
+            # OBB format: (1, 300, 7) - with angle
+            predictions = output[0]  # (300, 7)
+        elif output.shape[1] > output.shape[2]:
+            # Raw format: (1, 84, 8400) - need transpose
+            predictions = output[0].T  # (8400, 84)
         else:
-            raise ValueError(f"Unexpected input shape: {self.input_shape}")
+            # Assume processed format
+            predictions = output[0]
+    else:
+        predictions = output
 
-        # Initialize letterbox transformer
-        self.letterbox = LetterBox(
-            new_shape=(self.input_height, self.input_width),
-            auto=False,
-            scale_fill=False,
+    # Check if this is processed format (6 columns: x1,y1,x2,y2,conf,cls)
+    if predictions.shape[1] == 6:
+        # Already processed format: [x1, y1, x2, y2, conf, cls]
+        boxes = predictions[:, :4]
+        scores = predictions[:, 4]
+        class_ids = predictions[:, 5].astype(np.int32)
+
+        # Filter by confidence
+        mask = scores >= conf_thres
+        return boxes[mask], scores[mask], class_ids[mask]
+
+    # Raw YOLO output: (num_anchors, 4+classes)
+    boxes_cxcywh = predictions[:, :4]  # cx, cy, w, h
+    class_scores = predictions[:, 4:]  # class scores
+
+    # Get best class for each anchor
+    scores = class_scores.max(axis=1)
+    class_ids = class_scores.argmax(axis=1).astype(np.int32)
+
+    # Filter by confidence threshold
+    mask = scores >= conf_thres
+    boxes_cxcywh = boxes_cxcywh[mask]
+    scores = scores[mask]
+    class_ids = class_ids[mask]
+
+    if len(boxes_cxcywh) == 0:
+        return np.array([]), np.array([]), np.array([])
+
+    # Convert to xyxy format
+    boxes_xyxy = cxcywh_to_xyxy(boxes_cxcywh)
+
+    # Apply NMS
+    keep = nms_boxes(boxes_xyxy, scores, iou_thres)
+
+    return boxes_xyxy[keep], scores[keep], class_ids[keep]
+
+
+def postprocess_pose(
+    output: np.ndarray,
+    conf_thres: float = 0.25,
+    num_keypoints: int = 17,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Postprocess YOLO Pose output.
+
+    Input shape: (1, num_detections, 4+1+num_keypoints*3) e.g., (1, 300, 56)
+    Or: (1, num_detections, 4+1+1+num_keypoints*3) e.g., (1, 300, 57)
+    - 4: box coordinates (x1, y1, x2, y2)
+    - 1: confidence (box_conf * class_conf, or just box_conf for single-class)
+    - Optional 1: class score (often 0 for pose since only person class)
+    - 51: 17 keypoints * 3 (x, y, conf)
+
+    Output: boxes, scores, class_ids, keypoints
+    - keypoints: (N, 17, 3) - x, y, confidence for each keypoint
+    """
+    if isinstance(output, (list, tuple)):
+        output = output[0]
+
+    # output shape: (1, 300, 56) or (1, 300, 57)
+    predictions = output[0] if output.ndim == 3 else output
+
+    # Determine format based on number of columns
+    num_cols = predictions.shape[1]
+    if num_cols == 56:
+        # Format: 4 (box) + 1 (conf) + 51 (kpts)
+        boxes = predictions[:, :4]
+        scores = predictions[:, 4]
+        keypoints_flat = predictions[:, 5:]
+    elif num_cols == 57:
+        # Format: 4 (box) + 1 (box_conf) + 1 (cls) + 51 (kpts)
+        boxes = predictions[:, :4]
+        box_conf = predictions[:, 4]
+        class_scores = predictions[:, 5]
+        # For pose (single class), class_scores may be 0, so use box_conf directly
+        # or if class_scores is non-zero, use the product
+        if class_scores.max() > 0:
+            scores = box_conf * class_scores
+        else:
+            scores = box_conf
+        keypoints_flat = predictions[:, 6:]
+    else:
+        raise ValueError(f"Unexpected pose output shape: {predictions.shape}")
+
+    # Filter by confidence
+    mask = scores >= conf_thres
+    boxes = boxes[mask]
+    scores = scores[mask]
+    keypoints_flat = keypoints_flat[mask]
+
+    if len(boxes) == 0:
+        return (
+            np.array([]),
+            np.array([]),
+            np.array([]),
+            np.array([]).reshape(0, num_keypoints, 3),
         )
 
-        print(f"Model input: {self.input_shape} (NCHW)")
-        print(f"Input size: {self.input_width}x{self.input_height}")
+    # Reshape keypoints to (N, 17, 3)
+    keypoints = keypoints_flat.reshape(-1, num_keypoints, 3)
 
-    def preprocess(self, image_path):
-        """
-        Preprocess image using Ultralytics LetterBox.
+    # Class is always 0 for pose (person)
+    class_ids = np.zeros(len(boxes), dtype=np.int32)
 
-        Args:
-            image_path: Path to input image
+    # No NMS needed for pose output (already top-k)
+    return boxes, scores, class_ids, keypoints
 
-        Returns:
-            tuple: (preprocessed_tensor, original_image, letterbox_ratio)
-        """
-        # Read image
-        img = cv2.imread(image_path)
-        if img is None:
-            raise ValueError(f"Cannot read image: {image_path}")
 
-        original_shape = img.shape[:2]  # (height, width)
+def postprocess_segment(
+    output: Union[np.ndarray, List],
+    conf_thres: float = 0.25,
+    iou_thres: float = 0.45,
+    num_classes: int = 80,
+    num_masks: int = 32,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, Optional[np.ndarray]]:
+    """
+    Postprocess YOLO Segmentation output.
 
-        # Apply letterbox resize
-        img_letterbox = self.letterbox(image=img)
+    Supports two output formats:
+    1. Processed format: (1, num_detections, 4+1+1+num_masks) e.g., (1, 300, 38)
+       - 4: box (x1, y1, x2, y2)
+       - 1: confidence
+       - 1: class index
+       - 32: mask coefficients
+    2. Raw format: (1, 4+num_classes+num_masks, num_anchors) e.g., (1, 116, 8400)
 
-        # Calculate scale ratio for converting back
-        # letterbox scales and pads the image
-        ratio = min(self.input_width / img.shape[1], self.input_height / img.shape[0])
-
-        # BGR to RGB
-        img_rgb = cv2.cvtColor(img_letterbox, cv2.COLOR_BGR2RGB)
-
-        # HWC to CHW
-        img_chw = img_rgb.transpose(2, 0, 1)
-
-        # Normalize to 0-1 and convert to float32
-        img_normalized = img_chw.astype(np.float32) / 255.0
-
-        # Add batch dimension
-        img_batch = np.expand_dims(img_normalized, axis=0)
-
-        return img_batch, img, ratio, original_shape
-
-    def infer(self, input_tensor):
-        """
-        Run inference on NPU.
-
-        Args:
-            input_tensor: Preprocessed input tensor (NCHW format)
-
-        Returns:
-            numpy array: Raw model output
-        """
-        outputs = self.session.infer([input_tensor], mode="static")
-        return outputs
-
-    def postprocess(self, outputs, ratio, original_shape, classes=None):
-        """
-        Postprocess YOLO outputs: apply NMS and scale boxes back to original image.
-
-        YOLO output format: [batch, num_boxes, 6] where 6 = [x1, y1, x2, y2, conf, cls]
-
-        Args:
-            outputs: Raw model outputs
-            ratio: Scale ratio from preprocessing
-            original_shape: Original image shape (height, width)
-            classes: List of class names (optional)
-
-        Returns:
-            list: Detection results, each element is dict with 'box', 'conf', 'cls'
-        """
-        # Get predictions
-        if isinstance(outputs, (list, tuple)):
-            pred = outputs[0]
+    Output: boxes_xyxy, scores, class_ids, mask_coeffs
+    """
+    protos = None
+    if isinstance(output, (list, tuple)):
+        if len(output) == 2:
+            # Two outputs: (predictions, protos)
+            pred_output, protos = output
         else:
-            pred = outputs
+            pred_output = output[0]
+    else:
+        pred_output = output
 
-        # pred shape: [batch, num_boxes, 6]
-        pred = pred[0]  # Remove batch dimension: [num_boxes, 6]
+    # Handle detection output
+    if isinstance(pred_output, (list, tuple)):
+        pred_output = pred_output[0]
 
-        # Extract components - format is [x1, y1, x2, y2, conf, cls]
-        boxes = pred[:, :4]  # [x1, y1, x2, y2]
-        confs = pred[:, 4]  # confidence scores
-        clses = pred[:, 5]  # class indices
+    # Determine output format
+    if pred_output.ndim == 3:
+        if pred_output.shape[2] == 38 or pred_output.shape[2] == 37:
+            # Processed format: (1, 300, 38) - already decoded
+            predictions = pred_output[0]  # (300, 38)
 
-        # Filter by confidence threshold
-        mask = confs >= self.conf_thres
-        boxes = boxes[mask]
-        confs = confs[mask]
-        clses = clses[mask]
+            # Format: [x1, y1, x2, y2, conf, cls, mask_coeffs...]
+            boxes = predictions[:, :4]  # Already xyxy
+            scores = predictions[:, 4]
+            class_ids = predictions[:, 5].astype(np.int32)
+            mask_coeffs = predictions[:, 6 : 6 + num_masks]
 
-        # Apply NMS
-        if len(boxes) > 0:
-            if torch is not None and torchvision_nms is not None:
-                # Use torchvision NMS (faster)
-                keep = torchvision_nms(
-                    torch.from_numpy(boxes.copy()),
-                    torch.from_numpy(confs.copy()),
-                    self.iou_thres,
-                ).numpy()
-            else:
-                # Use numpy NMS
-                keep = nms_numpy(boxes, confs, self.iou_thres)
+            # Filter by confidence
+            mask = scores >= conf_thres
+            return boxes[mask], scores[mask], class_ids[mask], mask_coeffs[mask]
 
-            boxes = boxes[keep]
-            confs = confs[keep]
-            clses = clses[keep]
+        elif pred_output.shape[1] > pred_output.shape[2]:
+            # Raw format: (1, 116, 8400) - need transpose
+            predictions = pred_output[0].T  # (8400, 116)
+        else:
+            predictions = pred_output[0]
+    else:
+        predictions = pred_output
 
-        # Calculate padding offset (letterbox centers the image)
-        pad_h = (self.input_height - original_shape[0] * ratio) / 2
-        pad_w = (self.input_width - original_shape[1] * ratio) / 2
+    # Raw YOLO output: (num_anchors, 4+classes+masks)
+    boxes_cxcywh = predictions[:, :4]
+    class_scores = predictions[:, 4 : 4 + num_classes]
+    mask_coeffs = predictions[:, 4 + num_classes : 4 + num_classes + num_masks]
 
-        # Scale boxes back to original image size and remove padding offset
-        results = []
-        for i in range(len(boxes)):
-            x1, y1, x2, y2 = boxes[i]
+    # Get best class
+    scores = class_scores.max(axis=1)
+    class_ids = class_scores.argmax(axis=1).astype(np.int32)
 
-            # Remove padding offset and scale back
-            x1 = (x1 - pad_w) / ratio
-            y1 = (y1 - pad_h) / ratio
-            x2 = (x2 - pad_w) / ratio
-            y2 = (y2 - pad_h) / ratio
+    # Filter by confidence
+    mask = scores >= conf_thres
+    boxes_cxcywh = boxes_cxcywh[mask]
+    scores = scores[mask]
+    class_ids = class_ids[mask]
+    mask_coeffs = mask_coeffs[mask]
 
-            # Clip to image bounds
-            x1 = max(0, min(x1, original_shape[1]))
-            y1 = max(0, min(y1, original_shape[0]))
-            x2 = max(0, min(x2, original_shape[1]))
-            y2 = max(0, min(y2, original_shape[0]))
+    if len(boxes_cxcywh) == 0:
+        return (
+            np.array([]),
+            np.array([]),
+            np.array([]),
+            np.array([]).reshape(0, num_masks),
+        )
 
-            cls_idx = int(clses[i])
+    # Convert to xyxy
+    boxes_xyxy = cxcywh_to_xyxy(boxes_cxcywh)
 
-            results.append(
-                {
-                    "box": [float(x1), float(y1), float(x2), float(y2)],
-                    "conf": float(confs[i]),
-                    "cls": cls_idx,
-                    "cls_name": classes[cls_idx]
-                    if classes and cls_idx < len(classes)
-                    else str(cls_idx),
-                }
+    # Apply NMS
+    keep = nms_boxes(boxes_xyxy, scores, iou_thres)
+
+    return boxes_xyxy[keep], scores[keep], class_ids[keep], mask_coeffs[keep]
+
+
+def postprocess_obb(
+    output: np.ndarray,
+    conf_thres: float = 0.25,
+    iou_thres: float = 0.45,
+    num_classes: int = 15,
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Postprocess YOLO OBB (Oriented Bounding Box) output.
+
+    Supports two output formats:
+    1. Processed format: (1, num_detections, 7) e.g., (1, 300, 7)
+       - 4: box (cx, cy, w, h)
+       - 1: confidence
+       - 1: class index
+       - 1: angle in radians
+    2. Raw format: (1, 4+1+num_classes, num_anchors) e.g., (1, 20, 8400)
+
+    Output: boxes_xywh, scores, class_ids, angles
+    - boxes_xywh: (N, 4) - cx, cy, w, h
+    """
+    if isinstance(output, (list, tuple)):
+        output = output[0]
+
+    # Determine output format
+    if output.ndim == 3:
+        if output.shape[2] == 7:
+            # Processed format: (1, 300, 7)
+            # Format: [cx, cy, w, h, conf, cls, angle]
+            predictions = output[0]  # (300, 7)
+
+            boxes_cxcywh = predictions[:, :4]
+            scores = predictions[:, 4]
+            class_ids = predictions[:, 5].astype(np.int32)
+            angles = predictions[:, 6]
+
+            # Filter by confidence
+            mask = scores >= conf_thres
+            return (
+                boxes_cxcywh[mask],
+                scores[mask],
+                class_ids[mask],
+                angles[mask],
             )
+        elif output.shape[1] > output.shape[2]:
+            # Raw format: (1, 20, 8400) - need transpose
+            predictions = output[0].T  # (8400, 20)
+        else:
+            predictions = output[0]
+    else:
+        predictions = output
 
-        return results
+    # Raw YOLO output: (num_anchors, 4+1+classes)
+    boxes_cxcywh = predictions[:, :4]
+    angles = predictions[:, 4]  # angle in radians
+    class_scores = predictions[:, 5 : 5 + num_classes]
 
-    def __call__(self, image_path, classes=None):
-        """
-        Full inference pipeline.
+    # Get best class
+    scores = class_scores.max(axis=1)
+    class_ids = class_scores.argmax(axis=1).astype(np.int32)
 
-        Args:
-            image_path: Path to input image
-            classes: Optional list of class names
+    # Filter by confidence
+    mask = scores >= conf_thres
+    boxes_cxcywh = boxes_cxcywh[mask]
+    scores = scores[mask]
+    class_ids = class_ids[mask]
+    angles = angles[mask]
 
-        Returns:
-            dict: Results containing detections, timing info, etc.
-        """
-        start_time = time.time()
+    if len(boxes_cxcywh) == 0:
+        return np.array([]), np.array([]), np.array([]), np.array([])
 
-        # Preprocess
-        preprocess_start = time.time()
-        input_tensor, original_img, ratio, original_shape = self.preprocess(image_path)
-        preprocess_time = time.time() - preprocess_start
+    # Apply NMS (using standard NMS on rotated boxes approximation)
+    boxes_xyxy = cxcywh_to_xyxy(boxes_cxcywh)
+    keep = nms_boxes(boxes_xyxy, scores, iou_thres)
 
-        # Infer
-        infer_start = time.time()
-        outputs = self.infer(input_tensor)
-        infer_time = time.time() - infer_start
-
-        # Postprocess
-        postprocess_start = time.time()
-        detections = self.postprocess(outputs, ratio, original_shape, classes)
-        postprocess_time = time.time() - postprocess_start
-
-        total_time = time.time() - start_time
-
-        return {
-            "image_path": image_path,
-            "original_shape": original_shape,
-            "detections": detections,
-            "num_detections": len(detections),
-            "timing": {
-                "preprocess_ms": preprocess_time * 1000,
-                "infer_ms": infer_time * 1000,
-                "postprocess_ms": postprocess_time * 1000,
-                "total_ms": total_time * 1000,
-            },
-            "original_image": original_img,
-        }
-
-    def free_resource(self):
-        """Release NPU resources."""
-        self.session.free_resource()
+    return boxes_cxcywh[keep], scores[keep], class_ids[keep], angles[keep]
 
 
-def draw_results(result, output_path, classes=None):
-    """
-    Draw detection results on image and save.
+# =============================================================================
+# Visualization Functions
+# =============================================================================
 
-    Args:
-        result: Detection result from inferencer
-        output_path: Path to save output image
-        classes: List of class names
-    """
-    img = result["original_image"].copy()
+# COCO Keypoint skeleton connections (17 keypoints)
+SKELETON = [
+    (0, 1),
+    (0, 2),
+    (1, 3),
+    (2, 4),  # Head
+    (5, 6),
+    (5, 7),
+    (7, 9),
+    (6, 8),
+    (8, 10),  # Arms
+    (5, 11),
+    (6, 12),
+    (11, 12),  # Torso
+    (11, 13),
+    (13, 15),
+    (12, 14),
+    (14, 16),  # Legs
+]
 
-    def get_color(cls_id):
-        colors_list = [
-            (255, 0, 0),
-            (0, 255, 0),
-            (0, 0, 255),
-            (255, 255, 0),
-            (255, 0, 255),
-            (0, 255, 255),
-            (128, 0, 0),
-            (0, 128, 0),
-            (0, 0, 128),
-            (128, 128, 0),
-            (128, 0, 128),
-            (0, 128, 128),
-        ]
-        return colors_list[cls_id % len(colors_list)]
+# Colors for skeleton (left=blue, right=red)
+KPT_COLORS = [
+    (255, 0, 0),
+    (255, 85, 0),
+    (255, 170, 0),
+    (255, 255, 0),
+    (170, 255, 0),  # 0-4
+    (85, 255, 0),
+    (0, 255, 0),
+    (0, 255, 85),
+    (0, 255, 170),
+    (0, 255, 255),  # 5-9
+    (0, 170, 255),
+    (0, 85, 255),
+    (0, 0, 255),
+    (85, 0, 255),
+    (170, 0, 255),  # 10-14
+    (255, 0, 255),  # 15
+]
 
-    for det in result["detections"]:
-        x1, y1, x2, y2 = [int(v) for v in det["box"]]
-        conf = det["conf"]
-        cls = det["cls"]
-        label = f"{det['cls_name']} {conf:.2f}"
+LIMB_COLORS = [
+    (255, 0, 0),
+    (255, 0, 255),
+    (170, 0, 255),
+    (255, 0, 255),  # 0-1, 0-2, 1-3, 2-4
+    (255, 255, 0),
+    (255, 255, 0),
+    (85, 255, 0),
+    (255, 255, 0),
+    (85, 255, 0),  # 5-6, 5-7, 7-9, 6-8, 8-10
+    (255, 255, 0),
+    (255, 255, 0),
+    (255, 255, 0),  # 5-11, 6-12, 11-12
+    (0, 255, 0),
+    (0, 255, 0),
+    (0, 255, 0),
+    (0, 255, 0),  # 11-13, 13-15, 12-14, 14-16
+]
+
+
+def get_color(cls_id: int) -> Tuple[int, int, int]:
+    """Get a consistent color for a class ID."""
+    colors_list = [
+        (255, 0, 0),
+        (0, 255, 0),
+        (0, 0, 255),
+        (255, 255, 0),
+        (255, 0, 255),
+        (0, 255, 255),
+        (128, 0, 0),
+        (0, 128, 0),
+        (0, 0, 128),
+        (128, 128, 0),
+        (128, 0, 128),
+        (0, 128, 128),
+        (255, 128, 0),
+        (255, 0, 128),
+        (128, 255, 0),
+    ]
+    return colors_list[cls_id % len(colors_list)]
+
+
+def draw_detections(
+    img: np.ndarray,
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    class_ids: np.ndarray,
+    classes: Optional[List[str]] = None,
+) -> np.ndarray:
+    """Draw detection boxes on image."""
+    for i in range(len(boxes)):
+        x1, y1, x2, y2 = [int(v) for v in boxes[i]]
+        conf = scores[i]
+        cls = int(class_ids[i])
+        label = f"{classes[cls] if classes and cls < len(classes) else cls} {conf:.2f}"
         color = get_color(cls)
 
         cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
@@ -398,12 +580,460 @@ def draw_results(result, output_path, classes=None):
             1,
             cv2.LINE_AA,
         )
+    return img
+
+
+def draw_pose(
+    img: np.ndarray,
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    keypoints: np.ndarray,
+    conf_thres: float = 0.5,
+) -> np.ndarray:
+    """
+    Draw pose keypoints and skeleton on image.
+
+    Args:
+        img: Input image
+        boxes: Bounding boxes (N, 4)
+        scores: Confidence scores (N,)
+        keypoints: Keypoints array (N, 17, 3) - x, y, conf
+        conf_thres: Keypoint confidence threshold
+    """
+    for i in range(len(boxes)):
+        x1, y1, x2, y2 = [int(v) for v in boxes[i]]
+
+        # Draw bounding box
+        cv2.rectangle(img, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        cv2.putText(
+            img,
+            f"person {scores[i]:.2f}",
+            (x1, y1 - 10),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (0, 255, 0),
+            2,
+        )
+
+        kpts = keypoints[i]  # (17, 3)
+
+        # Draw skeleton connections
+        for j, (start, end) in enumerate(SKELETON):
+            if kpts[start, 2] > conf_thres and kpts[end, 2] > conf_thres:
+                pt1 = (int(kpts[start, 0]), int(kpts[start, 1]))
+                pt2 = (int(kpts[end, 0]), int(kpts[end, 1]))
+                color = LIMB_COLORS[j] if j < len(LIMB_COLORS) else (255, 255, 255)
+                cv2.line(img, pt1, pt2, color, 2, cv2.LINE_AA)
+
+        # Draw keypoints
+        for j, (x, y, conf) in enumerate(kpts):
+            if conf > conf_thres:
+                color = KPT_COLORS[j] if j < len(KPT_COLORS) else (255, 255, 255)
+                cv2.circle(img, (int(x), int(y)), 4, color, -1, cv2.LINE_AA)
+
+    return img
+
+
+def draw_segment(
+    img: np.ndarray,
+    boxes: np.ndarray,
+    scores: np.ndarray,
+    class_ids: np.ndarray,
+    mask_coeffs: Optional[np.ndarray],
+    classes: Optional[List[str]] = None,
+) -> np.ndarray:
+    """Draw segmentation results (boxes only, mask requires protos)."""
+    # For now, just draw boxes with segmentation label style
+    for i in range(len(boxes)):
+        x1, y1, x2, y2 = [int(v) for v in boxes[i]]
+        conf = scores[i]
+        cls = int(class_ids[i])
+        label = f"{classes[cls] if classes and cls < len(classes) else cls} {conf:.2f}"
+        color = get_color(cls)
+
+        # Semi-transparent overlay on box area
+        overlay = img.copy()
+        cv2.rectangle(overlay, (x1, y1), (x2, y2), color, -1)
+        cv2.addWeighted(overlay, 0.3, img, 0.7, 0, img)
+
+        # Box outline
+        cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
+
+        label_size, _ = cv2.getTextSize(label, cv2.FONT_HERSHEY_SIMPLEX, 0.6, 1)
+        label_y = y1 - 10 if y1 - 10 > 10 else y1 + 20
+        cv2.rectangle(
+            img,
+            (x1, label_y - label_size[1] - 4),
+            (x1 + label_size[0], label_y),
+            color,
+            -1,
+        )
+        cv2.putText(
+            img,
+            label,
+            (x1, label_y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.6,
+            (255, 255, 255),
+            1,
+            cv2.LINE_AA,
+        )
+    return img
+
+
+def draw_obb(
+    img: np.ndarray,
+    boxes: np.ndarray,
+    angles: np.ndarray,
+    scores: np.ndarray,
+    class_ids: np.ndarray,
+    classes: Optional[List[str]] = None,
+) -> np.ndarray:
+    """
+    Draw oriented bounding boxes on image.
+
+    Args:
+        boxes: (N, 4) - cx, cy, w, h
+        angles: (N,) - rotation angles in radians
+    """
+    for i in range(len(boxes)):
+        cx, cy, w, h = boxes[i]
+        angle = angles[i]
+        conf = scores[i]
+        cls = int(class_ids[i])
+        color = get_color(cls)
+
+        # Calculate rotated rectangle corners
+        cos_a, sin_a = np.cos(angle), np.sin(angle)
+        corners = np.array(
+            [[-w / 2, -h / 2], [w / 2, -h / 2], [w / 2, h / 2], [-w / 2, h / 2]]
+        )
+        rotation_matrix = np.array([[cos_a, -sin_a], [sin_a, cos_a]])
+        rotated_corners = corners @ rotation_matrix.T + [cx, cy]
+
+        # Draw rotated box
+        pts = rotated_corners.astype(np.int32).reshape((-1, 1, 2))
+        cv2.polylines(img, [pts], True, color, 2)
+
+        # Draw label
+        label = f"{classes[cls] if classes and cls < len(classes) else cls} {conf:.2f}"
+        cv2.putText(
+            img, label, (int(cx), int(cy) - 10), cv2.FONT_HERSHEY_SIMPLEX, 0.5, color, 1
+        )
+
+    return img
+
+
+# =============================================================================
+# Main Inferencer Class
+# =============================================================================
+
+
+class YoloOMInferencer:
+    """
+    YOLO OM Model Inferencer supporting multiple task types.
+
+    Supported tasks:
+    - detect: Object detection
+    - pose: Keypoint detection
+    - segment: Instance segmentation
+    - obb: Oriented bounding box detection
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        task: str = "detect",
+        device_id: int = 0,
+        imgsz: int = 640,
+        conf_thres: float = 0.25,
+        iou_thres: float = 0.45,
+    ):
+        self.model_path = model_path
+        self.task = task
+        self.device_id = device_id
+        self.imgsz = imgsz
+        self.conf_thres = conf_thres
+        self.iou_thres = iou_thres
+
+        # Load OM model
+        print(f"Loading OM model: {model_path}")
+        print(f"Task type: {task}")
+        self.session = InferSession(device_id=device_id, model_path=model_path)
+
+        # Get model info
+        self.input_info = self.session.get_inputs()[0]
+        self.input_shape = self.input_info.shape
+
+        if len(self.input_shape) == 4:
+            self.batch_size = self.input_shape[0] if self.input_shape[0] > 0 else 1
+            self.input_height = self.input_shape[2]
+            self.input_width = self.input_shape[3]
+        else:
+            raise ValueError(f"Unexpected input shape: {self.input_shape}")
+
+        # Initialize letterbox transformer
+        self.letterbox = LetterBox(
+            new_shape=(self.input_height, self.input_width),
+            auto=False,
+            scale_fill=False,
+        )
+
+        print(f"Model input: {self.input_shape} (NCHW)")
+        print(f"Input size: {self.input_width}x{self.input_height}")
+
+    def preprocess(
+        self, image_path: str
+    ) -> Tuple[np.ndarray, np.ndarray, float, Tuple[int, int]]:
+        """Preprocess image using Ultralytics LetterBox."""
+        img = cv2.imread(image_path)
+        if img is None:
+            raise ValueError(f"Cannot read image: {image_path}")
+
+        original_shape = img.shape[:2]  # (height, width)
+
+        # Apply letterbox resize
+        img_letterbox = self.letterbox(image=img)
+
+        # Calculate scale ratio
+        ratio = min(self.input_width / img.shape[1], self.input_height / img.shape[0])
+
+        # BGR to RGB, HWC to CHW, normalize
+        img_rgb = cv2.cvtColor(img_letterbox, cv2.COLOR_BGR2RGB)
+        img_chw = img_rgb.transpose(2, 0, 1)
+        img_normalized = img_chw.astype(np.float32) / 255.0
+        img_batch = np.expand_dims(img_normalized, axis=0)
+
+        return img_batch, img, ratio, original_shape
+
+    def infer(self, input_tensor: np.ndarray) -> List[np.ndarray]:
+        """Run inference on NPU."""
+        outputs = self.session.infer([input_tensor], mode="static")
+        return outputs
+
+    def postprocess(
+        self,
+        outputs: List[np.ndarray],
+        ratio: float,
+        original_shape: Tuple[int, int],
+        classes: Optional[List[str]] = None,
+    ) -> Dict:
+        """
+        Postprocess outputs based on task type.
+
+        Returns dict with task-specific results.
+        """
+        # Calculate padding offset (letterbox centers the image)
+        pad_h = (self.input_height - original_shape[0] * ratio) / 2
+        pad_w = (self.input_width - original_shape[1] * ratio) / 2
+
+        if self.task == "detect":
+            boxes, scores, class_ids = postprocess_detect(
+                outputs[0], self.conf_thres, self.iou_thres
+            )
+
+            # Scale boxes back to original image
+            detections = []
+            for i in range(len(boxes)):
+                x1, y1, x2, y2 = boxes[i]
+                x1 = max(0, min((x1 - pad_w) / ratio, original_shape[1]))
+                y1 = max(0, min((y1 - pad_h) / ratio, original_shape[0]))
+                x2 = max(0, min((x2 - pad_w) / ratio, original_shape[1]))
+                y2 = max(0, min((y2 - pad_h) / ratio, original_shape[0]))
+
+                cls_idx = int(class_ids[i])
+                detections.append(
+                    {
+                        "box": [float(x1), float(y1), float(x2), float(y2)],
+                        "conf": float(scores[i]),
+                        "cls": cls_idx,
+                        "cls_name": classes[cls_idx]
+                        if classes and cls_idx < len(classes)
+                        else str(cls_idx),
+                    }
+                )
+
+            return {"detections": detections, "num_detections": len(detections)}
+
+        elif self.task == "pose":
+            boxes, scores, class_ids, keypoints = postprocess_pose(
+                outputs[0], self.conf_thres
+            )
+
+            # Scale boxes and keypoints back to original image
+            poses = []
+            for i in range(len(boxes)):
+                x1, y1, x2, y2 = boxes[i]
+                x1 = max(0, min((x1 - pad_w) / ratio, original_shape[1]))
+                y1 = max(0, min((y1 - pad_h) / ratio, original_shape[0]))
+                x2 = max(0, min((x2 - pad_w) / ratio, original_shape[1]))
+                y2 = max(0, min((y2 - pad_h) / ratio, original_shape[0]))
+
+                # Scale keypoints
+                kpts = keypoints[i].copy()
+                kpts[:, 0] = (kpts[:, 0] - pad_w) / ratio
+                kpts[:, 1] = (kpts[:, 1] - pad_h) / ratio
+
+                poses.append(
+                    {
+                        "box": [float(x1), float(y1), float(x2), float(y2)],
+                        "conf": float(scores[i]),
+                        "keypoints": kpts.tolist(),
+                    }
+                )
+
+            return {"poses": poses, "num_poses": len(poses)}
+
+        elif self.task == "segment":
+            boxes, scores, class_ids, mask_coeffs = postprocess_segment(
+                outputs, self.conf_thres, self.iou_thres
+            )
+
+            # Scale boxes
+            detections = []
+            for i in range(len(boxes)):
+                x1, y1, x2, y2 = boxes[i]
+                x1 = max(0, min((x1 - pad_w) / ratio, original_shape[1]))
+                y1 = max(0, min((y1 - pad_h) / ratio, original_shape[0]))
+                x2 = max(0, min((x2 - pad_w) / ratio, original_shape[1]))
+                y2 = max(0, min((y2 - pad_h) / ratio, original_shape[0]))
+
+                cls_idx = int(class_ids[i])
+                mask_coeff = (
+                    mask_coeffs[i].tolist()
+                    if mask_coeffs is not None and i < len(mask_coeffs)
+                    else None
+                )
+                detections.append(
+                    {
+                        "box": [float(x1), float(y1), float(x2), float(y2)],
+                        "conf": float(scores[i]),
+                        "cls": cls_idx,
+                        "cls_name": classes[cls_idx]
+                        if classes and cls_idx < len(classes)
+                        else str(cls_idx),
+                        "mask_coeffs": mask_coeff,
+                    }
+                )
+
+            return {"detections": detections, "num_detections": len(detections)}
+
+        elif self.task == "obb":
+            boxes, scores, class_ids, angles = postprocess_obb(
+                outputs[0], self.conf_thres, self.iou_thres
+            )
+
+            # Scale boxes (cx, cy, w, h)
+            obbs = []
+            for i in range(len(boxes)):
+                cx, cy, w, h = boxes[i]
+                cx = (cx - pad_w) / ratio
+                cy = (cy - pad_h) / ratio
+                w = w / ratio
+                h = h / ratio
+
+                cls_idx = int(class_ids[i])
+                obbs.append(
+                    {
+                        "box": [float(cx), float(cy), float(w), float(h)],
+                        "angle": float(angles[i]),
+                        "conf": float(scores[i]),
+                        "cls": cls_idx,
+                        "cls_name": classes[cls_idx]
+                        if classes and cls_idx < len(classes)
+                        else str(cls_idx),
+                    }
+                )
+
+            return {"obbs": obbs, "num_obbs": len(obbs)}
+
+        return {}
+
+    def __call__(self, image_path: str, classes: Optional[List[str]] = None) -> Dict:
+        """Full inference pipeline."""
+        start_time = time.time()
+
+        # Preprocess
+        preprocess_start = time.time()
+        input_tensor, original_img, ratio, original_shape = self.preprocess(image_path)
+        preprocess_time = time.time() - preprocess_start
+
+        # Infer
+        infer_start = time.time()
+        outputs = self.infer(input_tensor)
+        infer_time = time.time() - infer_start
+
+        # Postprocess
+        postprocess_start = time.time()
+        result = self.postprocess(outputs, ratio, original_shape, classes)
+        postprocess_time = time.time() - postprocess_start
+
+        total_time = time.time() - start_time
+
+        result.update(
+            {
+                "image_path": image_path,
+                "original_shape": original_shape,
+                "task": self.task,
+                "timing": {
+                    "preprocess_ms": preprocess_time * 1000,
+                    "infer_ms": infer_time * 1000,
+                    "postprocess_ms": postprocess_time * 1000,
+                    "total_ms": total_time * 1000,
+                },
+                "original_image": original_img,
+            }
+        )
+
+        return result
+
+    def free_resource(self):
+        """Release NPU resources."""
+        self.session.free_resource()
+
+
+def draw_results(result: Dict, output_path: str, classes: Optional[List[str]] = None):
+    """Draw results on image based on task type."""
+    img = result["original_image"].copy()
+    task = result.get("task", "detect")
+
+    if task == "detect":
+        if result.get("detections"):
+            boxes = np.array([d["box"] for d in result["detections"]])
+            scores = np.array([d["conf"] for d in result["detections"]])
+            class_ids = np.array([d["cls"] for d in result["detections"]])
+            img = draw_detections(img, boxes, scores, class_ids, classes)
+
+    elif task == "pose":
+        if result.get("poses"):
+            boxes = np.array([p["box"] for p in result["poses"]])
+            scores = np.array([p["conf"] for p in result["poses"]])
+            keypoints = np.array([p["keypoints"] for p in result["poses"]])
+            img = draw_pose(img, boxes, scores, keypoints)
+
+    elif task == "segment":
+        if result.get("detections"):
+            boxes = np.array([d["box"] for d in result["detections"]])
+            scores = np.array([d["conf"] for d in result["detections"]])
+            class_ids = np.array([d["cls"] for d in result["detections"]])
+            mask_coeffs = np.array(
+                [d.get("mask_coeffs", []) for d in result["detections"]]
+            )
+            img = draw_segment(img, boxes, scores, class_ids, mask_coeffs, classes)
+
+    elif task == "obb":
+        if result.get("obbs"):
+            boxes = np.array([o["box"] for o in result["obbs"]])
+            angles = np.array([o["angle"] for o in result["obbs"]])
+            scores = np.array([o["conf"] for o in result["obbs"]])
+            class_ids = np.array([o["cls"] for o in result["obbs"]])
+            img = draw_obb(img, boxes, angles, scores, class_ids, classes)
 
     cv2.imwrite(output_path, img)
     print(f"Saved result to: {output_path}")
 
 
-# Default COCO classes
+# Default COCO classes for detection
 COCO_CLASSES = [
     "person",
     "bicycle",
@@ -487,6 +1117,25 @@ COCO_CLASSES = [
     "toothbrush",
 ]
 
+# DOTA classes for OBB
+DOTA_CLASSES = [
+    "plane",
+    "ship",
+    "storage tank",
+    "baseball diamond",
+    "tennis court",
+    "basketball court",
+    "ground track field",
+    "harbor",
+    "bridge",
+    "large vehicle",
+    "small vehicle",
+    "helicopter",
+    "roundabout",
+    "soccer ball field",
+    "swimming pool",
+]
+
 
 def main():
     parser = argparse.ArgumentParser(description="YOLO OM End-to-End Inference")
@@ -495,6 +1144,12 @@ def main():
         "--source", required=True, help="Path to input image or directory"
     )
     parser.add_argument("--output", help="Path to output image or directory")
+    parser.add_argument(
+        "--task",
+        choices=["detect", "pose", "segment", "obb"],
+        default="detect",
+        help="YOLO task type (default: detect)",
+    )
     parser.add_argument("--device", type=int, default=0, help="NPU device ID")
     parser.add_argument("--imgsz", type=int, default=640, help="Input image size")
     parser.add_argument("--conf", type=float, default=0.25, help="Confidence threshold")
@@ -509,19 +1164,28 @@ def main():
 
     args = parser.parse_args()
 
-    classes = args.classes if args.classes else COCO_CLASSES
+    # Select default classes based on task
+    if args.classes:
+        classes = args.classes
+    elif args.task == "obb":
+        classes = DOTA_CLASSES
+    else:
+        classes = COCO_CLASSES
 
     inferencer = YoloOMInferencer(
         model_path=args.model,
+        task=args.task,
         device_id=args.device,
         imgsz=args.imgsz,
         conf_thres=args.conf,
         iou_thres=args.iou,
     )
 
+    # Get input files
     if os.path.isfile(args.source):
         input_files = [args.source]
         output_dir = os.path.dirname(args.output) if args.output else "."
+        output_dir = output_dir if output_dir else "."  # Handle empty dirname
     elif os.path.isdir(args.source):
         input_files = (
             list(Path(args.source).glob("*.jpg"))
@@ -545,7 +1209,10 @@ def main():
 
         result = inferencer(img_path, classes=classes)
 
-        print(f"  Detections: {result['num_detections']}")
+        num_dets = result.get(
+            "num_detections", result.get("num_poses", result.get("num_obbs", 0))
+        )
+        print(f"  Detections: {num_dets}")
         print(
             f"  Timing: pre={result['timing']['preprocess_ms']:.1f}ms, "
             f"infer={result['timing']['infer_ms']:.1f}ms, "
@@ -553,16 +1220,24 @@ def main():
             f"total={result['timing']['total_ms']:.1f}ms"
         )
 
-        if result["detections"]:
+        # Print detections based on task type
+        detections = (
+            result.get("detections") or result.get("poses") or result.get("obbs") or []
+        )
+        if detections:
             print("  Objects:")
-            for det in result["detections"][:5]:
-                box = det["box"]
-                print(
-                    f"    - {det['cls_name']}: {det['conf']:.2f} at [{box[0]:.0f}, {box[1]:.0f}, {box[2]:.0f}, {box[3]:.0f}]"
-                )
-            if len(result["detections"]) > 5:
-                print(f"    ... and {len(result['detections']) - 5} more")
+            for det in detections[:5]:
+                if "keypoints" in det:
+                    print(f"    - person: {det['conf']:.2f} at {det['box'][:4]}")
+                else:
+                    box = det["box"]
+                    print(
+                        f"    - {det.get('cls_name', det.get('cls', '?'))}: {det['conf']:.2f} at {box}"
+                    )
+            if len(detections) > 5:
+                print(f"    ... and {len(detections) - 5} more")
 
+        # Save output
         base_name = Path(img_path).stem
         output_path = os.path.join(output_dir, f"{base_name}_result.jpg")
 
@@ -572,19 +1247,29 @@ def main():
         if args.save_txt:
             txt_path = os.path.join(output_dir, f"{base_name}.txt")
             with open(txt_path, "w") as f:
-                for det in result["detections"]:
-                    x1, y1, x2, y2 = det["box"]
-                    f.write(
-                        f"{det['cls']} {det['conf']:.4f} {x1:.1f} {y1:.1f} {x2:.1f} {y2:.1f}\n"
-                    )
+                for det in detections:
+                    if "keypoints" in det:
+                        # Pose format: class conf x1 y1 x2 y2 kpts...
+                        kpts_str = " ".join(
+                            [f"{v:.1f}" for kpt in det["keypoints"] for v in kpt]
+                        )
+                        f.write(
+                            f"0 {det['conf']:.4f} {det['box'][0]:.1f} {det['box'][1]:.1f} {det['box'][2]:.1f} {det['box'][3]:.1f} {kpts_str}\n"
+                        )
+                    else:
+                        box = det["box"]
+                        f.write(
+                            f"{det['cls']} {det['conf']:.4f} {box[0]:.1f} {box[1]:.1f} {box[2]:.1f} {box[3]:.1f}\n"
+                        )
             print(f"  Saved txt: {txt_path}")
 
-        total_detections += result["num_detections"]
+        total_detections += num_dets
         total_time += result["timing"]["total_ms"]
 
     print("\n" + "=" * 60)
     print("Summary")
     print("=" * 60)
+    print(f"Task type: {args.task}")
     print(f"Images processed: {len(input_files)}")
     print(f"Total detections: {total_detections}")
     print(f"Average time: {total_time / len(input_files):.1f}ms")


### PR DESCRIPTION
Fixes #11

## Summary
- Enhanced YOLO inference script to support multiple task types: detect, pose, segment, obb
- Fixed post-processing logic for YOLO output formats (raw vs processed)
- Added Pose visualization with keypoints and skeleton
- Improved SoC version warning in setup_env.sh
- Added YOLO_GUIDE.md with detailed output format reference
- Updated SKILL.md with task types table and SoC warnings

## Changes

### scripts/yolo_om_infer.py
- Add --task parameter to select task type
- Fix postprocess_detect() to handle both raw and processed formats
- Fix postprocess_pose() to use box_conf directly when class_scores is 0
- Fix postprocess_segment() to handle processed format
- Fix postprocess_obb() to handle processed format
- Add Pose visualization with 17 COCO keypoints and skeleton

### scripts/setup_env.sh
- Add colored output for better readability
- Add NPU device check with SoC version warning
- Add ATC command verification

### SKILL.md
- Reduce from 547 lines to 335 lines
- Add prominent SoC version matching warning
- Add YOLO task types table with output formats

### references/YOLO_GUIDE.md (new)
- Detailed YOLO output format reference

## Verification
Tested on Ascend910B3 with CANN 8.1.RC1
- yolo26n: 5 detections in 21ms
- yolo26n-pose: 3 poses in 21ms
- yolo26n-seg: 34 detections in 37ms
- yolo26n-obb: 171 detections in 28ms
