### PR TITLE
feat: add ascend-docker skill for container creation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,12 @@
       "description": "Complete toolkit for Huawei Ascend NPU model conversion and inference. Convert ONNX models to .om format using ATC tool, run Python inference on OM models using ais_bench, compare precision between CPU ONNX and NPU OM outputs, and end-to-end YOLO inference with Ultralytics.",
       "source": "./atc-model-converter",
       "category": "development"
+    },
+    {
+      "name": "ascend-docker",
+      "description": "Create Docker containers for Huawei Ascend NPU development with proper device mappings (davinci_manager, devmm_svm, hisi_hdc) and volume mounts (driver, sbin, home). Use when setting up Ascend development environments in Docker, running CANN applications in containers, or creating isolated NPU development workspaces.",
+      "source": "./ascend-docker",
+      "category": "operations"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A streamlined knowledge base for Huawei Ascend NPU development, structured as AI
 | [npu-smi](npu-smi/SKILL.md) | npu-smi device management: queries, configuration, firmware upgrades, virtualization, certificates |
 | [hccl-test](hccl-test/SKILL.md) | HCCL collective communication performance testing and benchmarking |
 | [atc-model-converter](atc-model-converter/SKILL.md) | ATC model conversion: ONNX to .om format, OM inference with ais_bench, precision comparison, YOLO end-to-end deployment |
+| [ascend-docker](ascend-docker/SKILL.md) | Docker container setup for Ascend NPU development with device mappings and volume mounts |
 
 ## Installation
 

--- a/ascend-docker/SKILL.md
+++ b/ascend-docker/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: ascend-docker
+description: Create Docker containers for Huawei Ascend NPU development with proper device mappings and volume mounts. Use when setting up Ascend development environments in Docker, running CANN applications in containers, or creating isolated NPU development workspaces. Supports privileged mode (default), basic mode, and full mode with profiling/logging. Auto-detects available NPU devices.
+---
+
+# Ascend Docker Container
+
+Create Docker containers configured for Huawei Ascend NPU development.
+
+## Quick Start
+
+```bash
+# Privileged mode (default, auto-detect all devices)
+./scripts/run-ascend-container.sh <image> <container_name>
+
+# Basic mode with specific devices
+./scripts/run-ascend-container.sh <image> <container_name> --mode basic
+
+# Full mode with selected devices
+./scripts/run-ascend-container.sh <image> <container_name> --mode full --device-list "0,1,2,3"
+```
+
+## Device Selection
+
+The script auto-detects available NPU devices from `/dev/davinci*`. Use `--device-list` to select specific devices:
+
+```bash
+# Use all detected devices (default)
+./scripts/run-ascend-container.sh <image> <container_name>
+
+# Use specific devices
+./scripts/run-ascend-container.sh <image> <container_name> --device-list "0,1,2,3"
+
+# Use device range
+./scripts/run-ascend-container.sh <image> <container_name> --device-list "0-3"
+
+# Combine ranges and individual devices
+./scripts/run-ascend-container.sh <image> <container_name> --device-list "0-3,7,10-11"
+```
+
+**Check available devices:**
+```bash
+ls /dev/davinci* | grep -oE 'davinci[0-9]+$'
+```
+
+## Container Modes
+
+### 1. Privileged Mode (Default)
+
+Maximum permissions, suitable when no specific requirements.
+
+```bash
+docker run -itd --privileged --name=<CONTAINER_NAME> --ipc=host --net=host \
+  --device=/dev/davinci_manager \
+  --device=/dev/devmm_svm \
+  --device=/dev/hisi_hdc \
+  -v /usr/local/sbin:/usr/local/sbin:ro \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+  -v /home:/home \
+  -w /home \
+  <IMAGE> \
+  /bin/bash
+```
+
+### 2. Basic Mode
+
+Specific device mapping with network host, for inference workloads.
+
+```bash
+docker run -itd --net=host \
+  --name=<CONTAINER_NAME> \
+  --device=/dev/davinci_manager \
+  --device=/dev/hisi_hdc \
+  --device=/dev/devmm_svm \
+  --device=/dev/davinci0 \
+  --device=/dev/davinci1 \
+  ... \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+  -v /usr/local/sbin:/usr/local/sbin:ro \
+  -v /etc/localtime:/etc/localtime \
+  -v /home:/home \
+  <IMAGE> \
+  /bin/bash
+```
+
+### 3. Full Mode
+
+With profiling, logging, dump, and add-ons support.
+
+```bash
+docker run -itd --ipc=host \
+  --name=<CONTAINER_NAME> \
+  --device=/dev/davinci_manager \
+  --device=/dev/devmm_svm \
+  --device=/dev/hisi_hdc \
+  --device=/dev/davinci0 \
+  --device=/dev/davinci1 \
+  ... \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  -v /usr/local/Ascend/add-ons/:/usr/local/Ascend/add-ons/ \
+  -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+  -v /usr/local/sbin/:/usr/local/sbin/ \
+  -v /var/log/npu/conf/slog/slog.conf:/var/log/npu/conf/slog/slog.conf \
+  -v /var/log/npu/slog/:/var/log/npu/slog \
+  -v /var/log/npu/profiling/:/var/log/npu/profiling \
+  -v /var/log/npu/dump/:/var/log/npu/dump \
+  -v /var/log/npu/:/usr/slog \
+  -v /etc/localtime:/etc/localtime \
+  -v /home:/home \
+  <IMAGE> \
+  /bin/bash
+```
+
+## Mode Comparison
+
+| Feature | Privileged | Basic | Full |
+|---------|------------|-------|------|
+| Network mode | host | host | - |
+| IPC mode | host | - | host |
+| Device access | All (via privileged) | Selected devices | Selected devices |
+| Profiling support | ✓ | ✗ | ✓ |
+| Dump support | ✓ | ✗ | ✓ |
+| Logging (slog) | ✓ | ✗ | ✓ |
+| Security | Lowest | Higher | Higher |
+
+## Device Parameters
+
+| Device | Purpose |
+|--------|---------|
+| `/dev/davinci_manager` | NPU device manager |
+| `/dev/devmm_svm` | Device memory management |
+| `/dev/hisi_hdc` | HDC communication device |
+| `/dev/davinci<N>` | Individual NPU devices (0, 1, 2, ...) |
+
+## Volume Parameters
+
+| Volume | Purpose |
+|--------|---------|
+| `/usr/local/Ascend/driver` | Ascend driver libraries |
+| `/usr/local/sbin` | NPU management tools (npu-smi) |
+| `/usr/local/Ascend/add-ons` | Additional Ascend components |
+| `/var/log/npu/slog` | System logs |
+| `/var/log/npu/profiling` | Profiling data |
+| `/var/log/npu/dump` | Dump data |
+| `/etc/localtime` | Timezone sync |
+| `/home` | User workspace |
+
+## Common Images
+
+```bash
+ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1
+ascendhub.huawei.com/public-ascendhub/ascend-mindspore:24.0.RC1
+ascendhub.huawei.com/public-ascendhub/ascend-toolkit:24.0.RC1
+```
+
+## Container Management
+
+```bash
+docker exec -it <container_name> bash
+docker stop <container_name>
+docker start <container_name>
+docker rm -f <container_name>
+```
+
+## Post-Setup
+
+For self-built images, configure environment variables:
+
+```bash
+echo 'source /usr/local/Ascend/ascend-toolkit/set_env.sh' >> ~/.bashrc
+source ~/.bashrc
+```
+
+## Official References
+
+- [Ascend Docker Guide](https://www.hiascend.com/document/detail/zh/300Vtest/300VG/300V_0032.html)

--- a/ascend-docker/scripts/run-ascend-container.sh
+++ b/ascend-docker/scripts/run-ascend-container.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# Create Ascend NPU Docker container with proper device mappings
+# Usage: run-ascend-container.sh <image> <container_name> [--mode privileged|basic|full] [--device-list "0,1,2,3"]
+
+set -e
+
+detect_devices() {
+  ls /dev/davinci* 2>/dev/null | grep -oE 'davinci[0-9]+$' | grep -oE '[0-9]+' | sort -n | tr '\n' ' ' | sed 's/ $//'
+}
+
+parse_device_list() {
+  local list="$1"
+  local devices=""
+  
+  if [ -z "$list" ]; then
+    devices=$(detect_devices)
+  else
+    IFS=',' read -ra parts <<< "$list"
+    for part in "${parts[@]}"; do
+      if [[ "$part" =~ ^([0-9]+)-([0-9]+)$ ]]; then
+        for ((i=${BASH_REMATCH[1]}; i<=${BASH_REMATCH[2]}; i++)); do
+          devices="$devices $i"
+        done
+      else
+        devices="$devices $part"
+      fi
+    done
+  fi
+  echo "$devices"
+}
+
+generate_device_args() {
+  local devices="$1"
+  local args=""
+  for dev in $devices; do
+    args="$args --device=/dev/davinci$dev"
+  done
+  echo "$args"
+}
+
+usage() {
+  local available=$(detect_devices)
+  local count=$(echo "$available" | wc -w)
+  echo "Usage: $0 <image> <container_name> [options]"
+  echo ""
+  echo "Options:"
+  echo "  --mode <mode>        Container mode: privileged (default), basic, full"
+  echo "  --device-list <list> Devices to mount (default: all detected)"
+  echo "                       Formats: \"0,1,2,3\" or \"0-3\" or \"0,2-4,7\""
+  echo ""
+  echo "Detected NPU devices: $available (total: $count)"
+  echo ""
+  echo "Modes:"
+  echo "  privileged  Maximum permissions (--privileged), suitable when no specific requirements"
+  echo "  basic       Specific devices with --net=host, for inference workloads"
+  echo "  full        With profiling, logging, dump support"
+  echo ""
+  echo "Examples:"
+  echo "  $0 ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1 my-ascend"
+  echo "  $0 ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1 my-ascend --mode basic"
+  echo "  $0 ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1 my-ascend --device-list \"0,1,2,3\""
+  echo "  $0 ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1 my-ascend --mode full --device-list \"0-7\""
+  exit 1
+}
+
+if [ $# -lt 2 ]; then
+  usage
+fi
+
+IMAGE=$1
+CONTAINER_NAME=$2
+shift 2
+
+MODE="privileged"
+DEVICE_LIST=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --device-list)
+      DEVICE_LIST="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      usage
+      ;;
+  esac
+done
+
+DEVICES=$(parse_device_list "$DEVICE_LIST")
+DEVICE_ARGS=$(generate_device_args "$DEVICES")
+
+run_privileged() {
+  docker run -itd --privileged --name=$CONTAINER_NAME --ipc=host --net=host \
+    --device=/dev/davinci_manager \
+    --device=/dev/devmm_svm \
+    --device=/dev/hisi_hdc \
+    -v /usr/local/sbin:/usr/local/sbin:ro \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+    -v /home:/home \
+    -w /home \
+    $IMAGE \
+    /bin/bash
+}
+
+run_basic() {
+  docker run -itd --net=host \
+    --name=$CONTAINER_NAME \
+    --device=/dev/davinci_manager \
+    --device=/dev/hisi_hdc \
+    --device=/dev/devmm_svm \
+    $DEVICE_ARGS \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver:ro \
+    -v /usr/local/sbin:/usr/local/sbin:ro \
+    -v /etc/localtime:/etc/localtime \
+    -v /home:/home \
+    $IMAGE \
+    /bin/bash
+}
+
+run_full() {
+  docker run -itd --ipc=host \
+    --name=$CONTAINER_NAME \
+    --device=/dev/davinci_manager \
+    --device=/dev/devmm_svm \
+    --device=/dev/hisi_hdc \
+    $DEVICE_ARGS \
+    -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+    -v /usr/local/Ascend/add-ons/:/usr/local/Ascend/add-ons/ \
+    -v /usr/local/sbin/npu-smi:/usr/local/sbin/npu-smi \
+    -v /usr/local/sbin/:/usr/local/sbin/ \
+    -v /var/log/npu/conf/slog/slog.conf:/var/log/npu/conf/slog/slog.conf \
+    -v /var/log/npu/slog/:/var/log/npu/slog \
+    -v /var/log/npu/profiling/:/var/log/npu/profiling \
+    -v /var/log/npu/dump/:/var/log/npu/dump \
+    -v /var/log/npu/:/usr/slog \
+    -v /etc/localtime:/etc/localtime \
+    -v /home:/home \
+    $IMAGE \
+    /bin/bash
+}
+
+case $MODE in
+  privileged)
+    run_privileged
+    ;;
+  basic)
+    run_basic
+    ;;
+  full)
+    run_full
+    ;;
+  *)
+    echo "Unknown mode: $MODE"
+    usage
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add new `ascend-docker` skill for creating Ascend NPU Docker containers
- Support three container modes: privileged (default), basic, full
- Auto-detect available NPU devices from `/dev/davinci*`
- Support flexible device selection with `--device-list` option
- Reference official Huawei documentation for container deployment

## Container Modes

| Mode | Use Case |
|------|----------|
| `privileged` | Default, maximum permissions when no specific requirements |
| `basic` | Specific device mapping with `--net=host`, for inference workloads |
| `full` | With profiling, logging, dump support for development |

## Device Selection

The script auto-detects available NPU devices. Use `--device-list` to select specific devices:

```bash
# Auto-detect all devices (default)
./scripts/run-ascend-container.sh <image> <container_name>

# Use specific devices
./scripts/run-ascend-container.sh <image> <container_name> --device-list "0,1,2,3"

# Use device range
./scripts/run-ascend-container.sh <image> <container_name> --device-list "0-3"

# Combine ranges and individual devices
./scripts/run-ascend-container.sh <image> <container_name> --device-list "0-3,7,10-11"
```

## Files Changed
- `ascend-docker/SKILL.md` - Skill documentation
- `ascend-docker/scripts/run-ascend-container.sh` - Container creation script
- `README.md` - Added skill to table
- `.claude-plugin/marketplace.json` - Added plugin entry

---

## Verification

Verified on server `175.99.1.3` with image `quay.io/ascend/vllm-ascend:v0.13.0`:

### Device Auto-Detection

```
$ bash run-ascend-container.sh
Detected NPU devices: 0 1 2 3 4 5 6 7 (total: 8)
```

### Test 1: Basic Mode with `--device-list "0,1"`

```bash
$ bash run-ascend-container.sh quay.io/ascend/vllm-ascend:v0.13.0 test-ascend-docker --mode basic --device-list "0,1"
8f00a86622d4046be1d17f5c1556559fad3982bbc116868b04d3e4c038461f95

$ docker exec test-ascend-docker ls -la /dev/davinci*
crw-rw----. 1 1000 1000 236, 0 Feb 25 06:57 /dev/davinci0
crw-rw----. 1 1000 1000 236, 1 Feb 25 06:57 /dev/davinci1
crw-rw----. 1 1000 1000 237, 0 Feb 25 06:57 /dev/davinci_manager
```
✅ Only davinci0, davinci1 mounted as expected

### Test 2: Full Mode with `--device-list "0-3"`

```bash
$ bash run-ascend-container.sh quay.io/ascend/vllm-ascend:v0.13.0 test-ascend-docker --mode full --device-list "0-3"
105ff7590f8ab7c9bd116ece2acfbcd5423d1c57dce98632a47d6acb9572ea74

$ docker exec test-ascend-docker ls -la /dev/davinci* /var/log/npu/
crw-rw----. 1 1000 1000 236, 0 Feb 25 06:58 /dev/davinci0
crw-rw----. 1 1000 1000 236, 1 Feb 25 06:58 /dev/davinci1
crw-rw----. 1 1000 1000 236, 2 Feb 25 06:58 /dev/davinci2
crw-rw----. 1 1000 1000 236, 3 Feb 25 06:58 /dev/davinci3
crw-rw----. 1 1000 1000 237, 0 Feb 25 06:58 /dev/davinci_manager

/var/log/npu/:
drwxr-xr-x. 3 root root 4096 Feb 25 06:58 conf
drwxr-xr-x. 2 root root 4096 Aug 18  2025 dump
drwxr-xr-x. 2 root root 4096 Aug 18  2025 profiling
drwxr-xr-x. 2 root root 4096 Aug 18  2025 slog
```
✅ Devices 0-3 mounted, profiling/dump/slog directories available

### Test Summary

| Test | Result |
|------|--------|
| Device auto-detection | ✅ Detected 8 devices |
| `--device-list "0,1"` | ✅ Only davinci0,1 mounted |
| `--device-list "0-3"` (range) | ✅ davinci0-3 mounted |
| Basic mode | ✅ Container created |
| Full mode | ✅ Container created with log dirs |

All tests passed. Test containers have been cleaned up.