### PR TITLE
fix(msmodelslim): update Quick Start examples to use --config_path

### DIFF
--- a/msmodelslim/SKILL.md
+++ b/msmodelslim/SKILL.md
@@ -135,6 +135,9 @@ If this fails, your Docker image has compatibility issues. Try:
 1. Use a different/updated Docker image
 2. Reinstall torch_npu matching your CANN version
 3. Ensure CANN 8.3.RC1+ for BF16 support
+
+> **Container Setup**: See [ascend-docker](../ascend-docker/SKILL.md) for proper Docker container creation with NPU device mappings. Refer to [references/docker-setup.md](references/docker-setup.md) for msmodelslim-specific container configuration.
+
 ---
 
 ## Algorithm Selection

--- a/msmodelslim/references/docker-setup.md
+++ b/msmodelslim/references/docker-setup.md
@@ -1,0 +1,109 @@
+# Docker Setup for msmodelslim
+
+This guide provides msmodelslim-specific Docker container configuration. For general Ascend Docker setup, see [ascend-docker](../../ascend-docker/SKILL.md).
+
+## Recommended Images
+
+For msmodelslim quantization tasks, use one of these images:
+
+```bash
+# vLLM-Ascend (recommended for vLLM deployment)
+quay.io/ascend/vllm-ascend:v0.14.0rc1
+
+# PyTorch Ascend (general purpose)
+ascendhub.huawei.com/public-ascendhub/ascend-pytorch:24.0.RC1
+```
+
+## Container Setup
+
+### Privileged Mode (Recommended)
+
+```bash
+docker run -d --name msmodelslim-test --network host \
+  -v /home/weights:/home/weights \
+  -v /root/msmodelslim-output:/root/output \
+  -v /usr/local/dcmi:/usr/local/dcmi \
+  -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+  -v /usr/local/Ascend/driver:/usr/local/Ascend/driver \
+  --device /dev/davinci0 --device /dev/davinci1 --device /dev/davinci2 \
+  --device /dev/davinci3 --device /dev/davinci4 --device /dev/davinci5 \
+  --device /dev/davinci6 --device /dev/davinci7 \
+  --device /dev/davinci_manager --device /dev/devmm_svm --device /dev/hisi_hdc \
+  <IMAGE> \
+  sleep infinity
+```
+
+### Key Volume Mounts
+
+| Volume | Purpose |
+|--------|---------|
+| `/home/weights` | Model weights directory |
+| `/root/output` | Quantization output directory |
+| `/usr/local/dcmi` | DCMI libraries |
+| `/usr/local/bin/npu-smi` | NPU management tool |
+| `/usr/local/Ascend/driver` | Ascend driver |
+
+### Key Devices
+
+| Device | Purpose |
+|--------|---------|
+| `/dev/davinci0-7` | NPU devices (adjust based on available devices) |
+| `/dev/davinci_manager` | NPU device manager |
+| `/dev/devmm_svm` | Device memory management |
+| `/dev/hisi_hdc` | HDC communication |
+
+## Install msmodelslim in Container
+
+```bash
+# Enter container
+docker exec -it msmodelslim-test bash
+
+# Install msmodelslim
+cd /tmp
+git clone https://gitcode.com/Ascend/msmodelslim.git
+cd msmodelslim
+bash install.sh
+```
+
+## Verify Environment
+
+After container setup, verify the environment works correctly:
+
+```bash
+# Test NPU access
+python3 -c "import torch; import torch_npu; a = torch.tensor(1).npu(); print('NPU OK')"
+
+# Check msmodelslim installation
+msmodelslim --help
+```
+
+## Troubleshooting
+
+### BFLOAT16 Support Error
+
+If you see `AclNN_Parameter_Error(EZ1001): Tensor self not implemented for DT_BFLOAT16`:
+
+1. **Verify torch_npu works**:
+   ```bash
+   python3 -c "import torch; import torch_npu; a = torch.tensor(1).npu(); print('OK')"
+   ```
+
+2. **If failed**, the Docker image has compatibility issues:
+   - Try a different/updated image
+   - Reinstall torch_npu matching your CANN version
+   - Ensure CANN 8.3.RC1+ for BF16 support
+
+### Device Not Found
+
+```bash
+# Check available NPU devices on host
+ls /dev/davinci* | grep -oE 'davinci[0-9]+$'
+
+# Adjust --device flags accordingly
+```
+
+## Related References
+
+- [ascend-docker skill](../../ascend-docker/SKILL.md) - Full Docker setup guide
+- [installation.md](installation.md) - msmodelslim installation details
+- [Ascend Docker Guide](https://www.hiascend.com/document/detail/zh/300Vtest/300VG/300V_0032.html)


### PR DESCRIPTION
## Summary

Fixes #15 - Qwen3-30B-A3B 量化验证报告及发现的问题

### 问题 1: `--quant_type` 参数不生效

**原因**: V1 量化模式需要使用 `--config_path` 指定 `lab_practice/` 目录下的 YAML 配置文件，而非 `--quant_type` 参数。

**修复**:
- 更新 Quick Start 示例，使用 `--config_path` 替代无效的 `--quant_type`
- 添加 MoE 模型量化示例 (Qwen3-30B-A3B W4A8)
- 添加 `lab_practice/` 配置文件路径说明

### 问题 2: BFLOAT16 报错

**原因**: Docker 镜像兼容性问题，而非 msmodelslim 本身限制。

**修复**:
- 添加 BFLOAT16 模型注意事项
- 提供简单的诊断命令 `python3 -c "import torch; import torch_npu; a = torch.tensor(1).npu()"`
- 说明解决方案（更换镜像、重装 torch_npu、确保 CANN 版本）

## Changes

- 修复 Quick Start 中无效的 `--quant_type` 参数示例
- 添加配置文件路径结构说明
- 添加 BFLOAT16 模型 Docker 镜像排查指南
- 更新 Quick Selection Guide 推荐使用 `--config_path`