### PR TITLE
fix(diffusers-ascend-weight-prep): Handle None library/class in model components

### DIFF
--- a/diffusers-ascend/diffusers-ascend-weight-prep/scripts/generate_fake_weights.py
+++ b/diffusers-ascend/diffusers-ascend-weight-prep/scripts/generate_fake_weights.py
@@ -81,6 +81,12 @@ def generate_from_local_metadata(
             continue
 
         library_name, class_name = comp_info
+
+        # Handle None values (skip components with no library/class)
+        if library_name is None or class_name is None:
+            print(f"\n--- {comp_name}: None (skipped) ---")
+            continue
+
         comp_metadata_dir = os.path.join(metadata_dir, comp_name)
         comp_output_dir = os.path.join(output_dir, comp_name)
 


### PR DESCRIPTION
## 变更描述

### 变更类型
- [ ] 新增 Skill
- [ ] 更新现有 Skill
- [x] 修复问题
- [ ] 其他（请说明）

### 涉及的 Skill
Skill 名称：diffusers-ascend-weight-prep

### 变更内容摘要
修复 `generate_fake_weights.py` 脚本在处理 model_index.json 中包含 `null` 值的组件时崩溃的问题。例如 Wan2.2-TI2V-5B 模型的 `transformer_2: [null, null]` 会导致 `TypeError: argument of type 'NoneType' is not iterable`。

---

## 检查清单

提交 PR 前，请确认以下检查项已完成：

### SKILL.md 格式检查
- [x] `name` 字段与目录名完全匹配
- [x] `description` 字段不少于 20 个字符
- [x] frontmatter 格式正确（以 `---` 开头和结尾）
- [x] 包含 `description` 字段用于 Agent 匹配
- [x] 正文中无 `[TODO]` 或 `[TODO:xxx]` 占位符

### 内容完整性检查
- [x] 内部链接可正常访问（如 `references/xxx.md`）
- [x] 代码块已标注语言（如 ```bash、```python）
- [x] 表格格式正确（如有）

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`
- [x] 已更新 `README.md` 中的 Skill 列表（如适用）

---

## 测试说明

### 本地验证
运行以下命令进行本地验证：

```bash
# 验证所有 Skill 文件
python3 scripts/validate_skills.py
```

**验证结果：**
```
Found 13 SKILL.md files
✅ diffusers-ascend/diffusers-ascend-weight-prep/SKILL.md
...
==================================================
Summary: 13 files checked
  Errors: 0
  Warnings: 0

✅ Validation PASSED!
```

### 本地测试截图

#### 1. 验证脚本测试结果

<!-- 运行 `python3 scripts/validate_skills.py` 后粘贴截图 -->

```
Found 13 SKILL.md files

✅ .agents/skills/create-pr/SKILL.md
✅ .agents/skills/skill-creator/SKILL.md
✅ ais-bench/SKILL.md
✅ ascend-docker/SKILL.md
✅ ascendc/SKILL.md
✅ atc-model-converter/SKILL.md
✅ diffusers-ascend/diffusers-ascend-env-setup/SKILL.md
✅ diffusers-ascend/diffusers-ascend-weight-prep/SKILL.md
✅ hccl-test/SKILL.md
✅ msmodelslim/SKILL.md
✅ npu-smi/SKILL.md
✅ torch_npu/SKILL.md
✅ vllm-ascend/SKILL.md

==================================================
Summary: 13 files checked
  Errors: 0
  Warnings: 0

✅ Validation PASSED!
```

#### 2. Skill 功能测试（如适用）

- [x] 已在 AI Agent 中测试 Skill 触发
- [x] 已验证 Skill 内容正确加载

**测试截图：**

已在远程服务器验证修复有效：

1. **修复前**：处理 `Wan-AI/Wan2.2-TI2V-5B-Diffusers` 时会报错：
   ```
   TypeError: argument of type 'NoneType' is not iterable
   ```

2. **修复后**：脚本正确处理 `transformer_2: [null, null]` 并输出：
   ```
   --- transformer_2: None (skipped) ---
   ```

3. **完整验证**：成功生成 24GB 假权重，并在 diffusers 中加载：
   ```
   ✅ Successfully loaded pipeline: WanPipeline
   
   Pipeline components:
     vae: AutoencoderKLWan (704,688,668 params)
     text_encoder: UMT5EncoderModel (6,731,059,200 params)
     tokenizer: T5Tokenizer
     transformer: WanTransformer3DModel (4,999,787,712 params)
     scheduler: UniPCMultistepScheduler
     transformer_2: None
   
   Total parameters: 12,435,535,580
   
   ✅ All fake weights loaded successfully!
   ```

详细验证报告已发布到 Discussion #47。

### CI 检查
提交 PR 后将自动运行以下检查：
1. **Validate SKILL.md files** - 验证所有 SKILL.md 文件格式
2. **Check frontmatter** - 检查 frontmatter 完整性
3. **Verify skill names** - 验证 name 字段与目录名匹配
4. **Check for broken internal links** - 检查内部链接是否损坏

---

## 其他说明

### 关联 Issue

Fixes #37

### 变更详情

**问题描述**：
某些 Diffusers pipeline 的 `model_index.json` 中包含值为 `[null, null]` 的组件，例如：
```json
{
  "_class_name": "WanPipeline",
  "transformer": ["diffusers", "WanTransformer3DModel"],
  "transformer_2": [null, null],
  ...
}
```

原代码在第 99 行执行 `"Scheduler" in class_name` 时，如果 `class_name` 为 `None`，会抛出 `TypeError`。

**修复方案**：
在解析 `library_name` 和 `class_name` 后立即检查是否为 `None`，如果是则跳过该组件的处理：

```python
library_name, class_name = comp_info

# Handle None values (skip components with no library/class)
if library_name is None or class_name is None:
    print(f"\n--- {comp_name}: None (skipped) ---")
    continue
```

**已验证模型**：
- ✅ Wan-AI/Wan2.2-TI2V-5B-Diffusers (12.4B 参数)

