### PR TITLE
feat(ascend-diffusion-adapt): Add CUDA to Ascend NPU diffusion model adaptation skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,6 +63,12 @@
       "category": "development"
     },
     {
+      "name": "ascend-diffusion-adapt",
+      "description": "Comprehensive guide for adapting HuggingFace Diffusers and custom diffusion models (Stable Diffusion, SDXL, FLUX, Wan2.1/2.2, CogVideoX, HunyuanVideo) from CUDA/GPU to Huawei Ascend NPU. Covers device migration, attention replacement (flash_attn/xformers → torch_npu/mindiesd), operator swaps (RMSNorm, RoPE, LayerNorm, Conv3d), distributed parallelism (CFG/Ulysses/Ring/TP/FSDP), VAE optimization, quantization (W8A8/W4A8), and attention caching.",
+      "source": "./ascend-diffusion-adapt",
+      "category": "development"
+    },
+    {
       "name": "diffusers-ascend-skills",
       "description": "Diffusers 昇腾 NPU 技能集，包括环境配置、权重准备、Pipeline 推理等。当用户需要在昇腾 NPU 上运行 Diffusers 推理时使用。",
       "source": "./",

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ cp -r awesome-ascend-skills/npu-smi your-project/.agents/skills/
 | [ais-bench](ais-bench/SKILL.md) | 测试 | AI 模型评估工具：精度评估（MMLU/GSM8K/MMMU 等 15+ 基准）、性能压测、Function Call |
 | [ascendc](ascendc/SKILL.md) | 开发 | AscendC 算子开发：FFN/GMM/MoE 等 Transformer 算子实现、CANN API 示例 |
 | [torch_npu](torch_npu/SKILL.md) | 开发 | PyTorch 昇腾扩展：环境检查、部署指引、PyTorch 迁移到 NPU 的完整指南 |
+| [ascend-diffusion-adapt](ascend-diffusion-adapt/SKILL.md) | 开发 | Diffusion 模型昇腾适配：CUDA→NPU 迁移、Attention/算子替换、分布式并行、量化部署 |
 | [diffusers-ascend-env-setup](diffusers-ascend/diffusers-ascend-env-setup/SKILL.md) | 开发 | Diffusers 环境配置：CANN 版本检测、PyTorch + torch_npu 安装、Diffusers 安装验证 |
 | [diffusers-ascend-weight-prep](diffusers-ascend/diffusers-ascend-weight-prep/SKILL.md) | 开发 | Diffusers 权重准备：HuggingFace/ModelScope 模型下载、基于 config.json 生成假权重用于验证 |
 | [diffusers-ascend-pipeline](diffusers-ascend/diffusers-ascend-pipeline/SKILL.md) | 开发 | Diffusers Pipeline 推理：环境预检、通用推理（图像/视频）、内存优化、LoRA 集成 |

--- a/ascend-diffusion-adapt/SKILL.md
+++ b/ascend-diffusion-adapt/SKILL.md
@@ -1,0 +1,341 @@
+---
+name: ascend-diffusion-adapt
+description: Comprehensive guide for adapting HuggingFace Diffusers and custom diffusion models (Stable Diffusion, SDXL, FLUX, Wan2.1/2.2, CogVideoX, HunyuanVideo) from CUDA/GPU to Huawei Ascend NPU. Covers device migration, attention replacement (flash_attn/xformers → torch_npu/mindiesd), operator swaps (RMSNorm, RoPE, LayerNorm, Conv3d), distributed parallelism (CFG/Ulysses/Ring/TP/FSDP), VAE optimization, quantization (W8A8/W4A8), attention caching, and runtime tuning. Use when porting diffusion/generative models to Ascend NPU, replacing CUDA attention, setting up multi-NPU inference, quantizing DiT/UNet/VAE, or debugging NPU-specific issues in diffusion workloads.
+keywords:
+    - ascend
+    - NPU
+    - torch_npu
+    - mindiesd
+    - diffusion
+    - CUDA迁移
+    - 模型适配
+    - 910B
+    - 910C
+    - attention替换
+    - 分布式推理
+    - 量化部署
+---
+
+# Ascend Diffusion Model Adaptation Guide
+
+This skill captures battle-tested patterns for migrating diffusion models from CUDA to Huawei Ascend NPU, derived from real-world adaptation of the Wan2.2 video generation model. The patterns generalize to any diffusion architecture using attention, convolutions, and iterative denoising.
+
+## Quick-Start: Adaptation Checklist
+
+For any diffusion model migration, work through these layers in order:
+
+1. **Device & Backend** — Swap CUDA references to NPU, switch NCCL to HCCL
+2. **Operator Replacement** — Replace flash_attn/xformers with torch_npu/mindiesd fused ops
+3. **Normalization & Embedding** — Swap RMSNorm/LayerNorm/RoPE to fused NPU kernels
+4. **Convolution Optimization** — Restructure padding for NPU-friendly Conv3d/Conv2d
+5. **Distributed Parallelism** — Configure FSDP + sequence/tensor/CFG parallelism
+6. **VAE Optimization** — Patch parallel decode, tiling, slicing
+7. **Quantization** (optional) — W8A8/W4A8 via mindiesd
+8. **Attention Caching** (optional) — Skip redundant attention in denoising steps
+9. **Runtime Tuning** — Warmup, compilation flags, environment variables
+
+Each layer has a dedicated reference file with code examples. Read them as needed — don't load everything upfront.
+
+---
+
+## 1. Device & Backend Migration
+
+The foundation of any Ascend port. Two approaches exist:
+
+### Approach A: Monkey-Patch (Recommended for Quick Ports)
+
+```python
+import torch_npu
+from torch_npu.contrib import transfer_to_npu  # Intercepts cuda calls → NPU
+
+# After this import, torch.device("cuda:0") transparently maps to npu:0
+# torch.cuda.set_device() → torch.npu.set_device(), etc.
+```
+
+This is the fastest path — many CUDA codebases work with just this import. However, you still need to manually fix:
+- Distributed backend: `nccl` → `hccl`
+- AMP autocast device: `torch.amp.autocast('cuda')` → `torch.amp.autocast('npu')`
+- Explicit device checks: `if device.type == 'cuda'` → `if device.type == 'npu'`
+
+### Approach B: Explicit Migration (Recommended for Production)
+
+Replace all CUDA references directly. More work upfront but clearer code.
+
+**See:** `references/device-migration-checklist.md` for the exhaustive find-and-replace list.
+
+### Compilation & Internal Format Flags
+
+Always set these early in your entry point:
+
+```python
+import torch_npu
+torch_npu.npu.set_compile_mode(jit_compile=False)  # Disable JIT compilation
+torch.npu.config.allow_internal_format = False       # Force standard tensor layouts
+```
+
+`jit_compile=False` avoids graph compilation overhead that hurts iterative denoising workloads. `allow_internal_format=False` ensures tensor layouts remain interoperable across operators — critical when mixing torch_npu native ops with mindiesd ops.
+
+---
+
+## 2. Attention Replacement
+
+This is the highest-impact change. CUDA diffusion models typically use `flash_attn` or `xformers`. On Ascend, replace with a tiered fallback:
+
+```
+Priority 1: attention_forward (from mindiesd) — fused, fastest
+Priority 2: torch_npu.npu_fused_infer_attention_score (native NPU op)
+Priority 3: torch.nn.functional.scaled_dot_product_attention (portable fallback)
+```
+
+The attention replacement is non-trivial because diffusion models use both:
+- **Standard self/cross-attention** (fixed sequence length)
+- **Variable-length attention** (flash_attn_varlen_func) for packed sequences
+
+Both need replacement. The Ascend approach also enables runtime algorithm selection via environment variables, which is valuable for benchmarking different attention backends without code changes.
+
+**See:** `references/attention-patterns.md` for complete replacement code with all algorithm paths.
+
+### Sparse Attention (Advanced Optimization)
+
+For video diffusion models with long sequences (>16K tokens), sparse attention patterns can skip computation on less-important tokens:
+- **Grid-based sparsity** — Sample tokens on a regular grid for early denoising steps
+- **Blockwise sparsity** — Skip entire spatial blocks based on attention score thresholds
+
+This is model-specific and requires tuning the sparsity ratio per model architecture.
+
+---
+
+## 3. Operator Replacement (Normalization, Embedding, Activation)
+
+Beyond attention, several operators have fused NPU equivalents that provide 1.2-3x speedup:
+
+| Original | Ascend Replacement | Speedup |
+|----------|--------------------|---------|
+| Manual RMSNorm (`torch.rsqrt`) | `torch_npu.npu_rms_norm(x, weight)` | ~2x |
+| `nn.LayerNorm(x)` | `fast_layernorm(norm_module, x)` from mindiesd | ~1.5x |
+| Complex RoPE application | `rotary_position_embedding(x, cos, sin, rotated_mode=..., fused=True)` | ~2x |
+| Complex RoPE application | `torch_npu.npu_apply_rotary_pos_emb(...)` | ~1.8x |
+
+**See:** `references/operator-replacement.md` for before/after code for each operator.
+
+### Key Pattern: Environment-Variable Dispatch
+
+The Ascend adaptation uses env vars to select operator implementations at runtime:
+
+```python
+ALGO = int(os.environ.get("ALGO", "0"))        # Attention algorithm
+ROPE_OPT = int(os.environ.get("ROPE_OPT", "0"))  # RoPE implementation
+FAST_LN = int(os.environ.get("FAST_LAYERNORM", "0"))  # LayerNorm implementation
+```
+
+This pattern is worth adopting — it lets you benchmark different operator paths without redeploying code, and gives users knobs to tune for their specific hardware generation (910B vs 910C have different optimal paths).
+
+---
+
+## 4. Convolution Optimization
+
+For video models using `CausalConv3d`, there's a subtle but important padding restructure:
+
+**Original:** All padding (spatial + temporal) applied via `F.pad` before convolution
+**Ascend:** Spatial padding moved INTO the Conv3d kernel, only temporal padding via `F.pad`
+
+```python
+# Original
+self.padding = (0, 0, 0)  # No padding in Conv3d
+x = F.pad(x, (spatial_w, spatial_w, spatial_h, spatial_h, temporal, 0))
+
+# Ascend — let Conv3d handle spatial padding natively
+self.padding = (0, pad_h, pad_w)  # Spatial padding in Conv3d kernel
+self._padding = (0, 0, 0, 0, temporal, 0)  # Only temporal via F.pad
+x = F.pad(x, self._padding)
+```
+
+Why this matters: NPU convolution kernels are optimized for standard padding patterns. Moving spatial padding into the kernel lets the NPU fuse the padding with the convolution, avoiding a separate memory-bound pad operation.
+
+---
+
+## 5. Distributed Parallelism
+
+Ascend supports richer parallelism than typical CUDA setups. For diffusion inference, the key strategies are:
+
+| Strategy | What It Parallelizes | When to Use |
+|----------|---------------------|-------------|
+| **CFG Parallel** | Conditional/unconditional branches | Always for CFG-based inference (2 devices) |
+| **Ulysses SP** | Sequence dimension (attention) | Long sequences, video models |
+| **Ring Attention** | Sequence dimension (ring-style) | Very long sequences, memory-limited |
+| **Tensor Parallel** | Weight matrices | Large models that don't fit single device |
+| **FSDP** | Full model sharding | Training and large-model inference |
+| **VAE Patch Parallel** | VAE decode patches | High-resolution output |
+
+These compose orthogonally. Total devices = `cfg_size × ulysses_size × ring_size × tp_size`.
+
+**See:** `references/parallelism-guide.md` for setup code, process group configuration, and composition examples.
+
+### CFG Parallelism (Unique to Ascend)
+
+Standard diffusion inference runs the denoising UNet/DiT twice per step — once with the prompt (conditional) and once without (unconditional) for classifier-free guidance. CFG parallelism splits these across 2 devices:
+
+```python
+if cfg_parallel:
+    # Each device runs ONE forward pass instead of TWO
+    noise_pred = model(x, t, context)  # conditional OR unconditional
+    noise_pred = all_gather(noise_pred)  # Combine results
+    noise_pred = unconditional + guidance_scale * (conditional - unconditional)
+```
+
+This halves per-device memory and nearly doubles throughput for CFG-based inference.
+
+---
+
+## 6. VAE Optimization
+
+VAE decode is often the memory bottleneck for high-resolution outputs. Key optimizations:
+
+- **Patch Parallel Decode** — Split the latent spatially across devices, decode in parallel, stitch results
+- **Tiling/Slicing** — For single-device: decode in spatial tiles with overlap to avoid seam artifacts
+- **CPU Offload** — Move VAE to CPU during denoising, back to NPU for final decode
+
+**See:** `references/parallelism-guide.md` (VAE section) for patch parallel implementation.
+
+---
+
+## 7. Quantization
+
+mindiesd provides turnkey quantization for DiT/UNet models:
+
+```python
+from mindiesd import quantize
+
+# find_quant_config_file returns (path, use_nz) tuple
+quant_des_path, use_nz = find_quant_config_file(quant_dir)
+quantize(model=model, quant_des_path=quant_des_path, use_nz=use_nz)
+```
+
+Supported schemes: W8A8 (dynamic), W4A4 (MXFP4 dual-scale), W8A8 (MXFP8).
+
+**Key API details:**
+- Parameter is `quant_des_path` (description path), NOT `quant_config_path`
+- `use_nz` controls NZ compression format (True for w8a8_dynamic/w4a4, False for mxfp8)
+- Config filenames follow pattern: `quant_model_description_<scheme>.json`
+
+**See:** `references/quantization-guide.md` for config file format and FSDP integration patterns.
+
+---
+
+## 8. Attention Caching
+
+For iterative denoising, adjacent timesteps produce similar attention patterns. Attention caching skips recomputation when the change is below a threshold:
+
+```python
+from mindiesd import CacheConfig, CacheAgent
+
+config = CacheConfig(
+    method="attention_cache",
+    blocks_count=len(model.blocks) * 2 // cfg_size,  # Total cacheable blocks
+    steps_count=sample_steps,                          # Total denoising steps
+    step_start=2,                                      # Start caching at step 2
+    step_interval=5,                                   # Recompute every 5 steps
+    step_end=45,                                       # Stop caching at step 45
+)
+for block in model.blocks:
+    block.cache = CacheAgent(config)
+    # During inference: block.cache.apply(block.self_attn, hidden_states, ...)
+```
+
+Parameters to tune: `step_start`/`step_end` (caching window), `step_interval` (recompute frequency), `blocks_count` (number of cacheable blocks). Caching too aggressively degrades quality; start with a wide interval (step_interval=5) and narrow down.
+
+---
+
+## 9. Runtime Tuning
+
+### Warmup Steps
+
+NPU graph compilation happens on first execution. Always run 2 warmup steps before timing or actual generation:
+
+```python
+# Warmup with dummy inputs matching real shapes
+for _ in range(2):
+    with torch.no_grad():
+        _ = model(dummy_input, dummy_timestep, dummy_context)
+torch.npu.synchronize()
+```
+
+### Timing
+
+Use NPU stream synchronization for accurate timing:
+
+```python
+torch.npu.synchronize()
+start = time.time()
+# ... generation ...
+torch.npu.synchronize()
+elapsed = time.time() - start
+```
+
+### Numerical Precision
+
+For reproducible results across runs, generate random noise on CPU:
+
+```python
+if os.environ.get("PRECISION", "0") == "1":
+    noise = torch.randn(shape, dtype=dtype, device="cpu").to("npu")
+else:
+    noise = torch.randn(shape, dtype=dtype, device="npu")
+```
+
+NPU random number generation may produce different sequences across runs even with the same seed. CPU-generated noise is deterministic.
+
+### Environment Variables Summary
+
+| Variable | Values | Default | Purpose |
+|----------|--------|---------|---------|
+| `ALGO` | 0, 1, 3 | 0 | Attention: 0=fused_attn, 1=laser_attn, 3=npu_fused_infer |
+| `ROPE_OPT` | 0, 1 | 0 | 0=mindiesd RoPE, 1=torch_npu RoPE |
+| `FAST_LAYERNORM` | 0, 1 | 0 | 0=standard, 1=mindiesd fast layernorm |
+| `USE_SUB_HEAD` | 0, N | 0 | Split attention into N sub-head groups (memory saving) |
+| `PRECISION` | 0, 1 | 0 | 1=CPU-based RNG for reproducibility |
+| `T5_LOAD_CPU` | 0, 1 | 0 | 1=Load T5 text encoder on CPU first |
+
+---
+
+## 10. Dependencies
+
+### Required
+- `torch_npu` (matching your CANN version)
+- `torch` (2.1.0 or 2.5.0/2.6.0 depending on CANN)
+
+### Recommended for Acceleration
+- `mindiesd` (MindIE SD — fused attention, RoPE, LayerNorm, quantization, caching)
+- `yunchang==0.6.0` (ring attention support)
+
+### Removed from CUDA Version
+- `flash_attn` — replaced by torch_npu/mindiesd attention
+- `xformers` — replaced by torch_npu/mindiesd attention
+- `torchaudio` — typically unused in Ascend inference pipelines
+
+---
+
+## 11. Common Pitfalls
+
+1. **Forgetting `allow_internal_format=False`** — Causes silent data corruption when mixing operator backends
+2. **Using `nccl` backend** — Will crash. Must use `hccl` for Ascend distributed
+3. **Flash attention imports at module level** — Guard with `try/except` or remove entirely
+4. **FSDP `use_orig_params`** — Remove this parameter on Ascend; it's not supported the same way
+5. **Timing without `npu.synchronize()`** — NPU ops are async; times will be wrong without sync
+6. **Large batch VAE decode** — Will OOM. Use tiling, slicing, or patch parallel
+7. **Skipping warmup** — First 1-2 iterations are 10-100x slower due to graph compilation
+8. **bf16 for attention** — Always cast attention inputs to `torch.bfloat16` on Ascend for best performance; fp16 attention has known precision issues on 910B
+
+---
+
+## Reference Files
+
+Read these for detailed code examples when implementing each adaptation layer:
+
+| File | Contents | When to Read |
+|------|----------|-------------|
+| `references/device-migration-checklist.md` | Exhaustive find-and-replace list for CUDA→NPU | Starting any migration |
+| `references/attention-patterns.md` | Full attention replacement with all algorithm paths | Replacing flash_attn/xformers |
+| `references/operator-replacement.md` | Before/after for RMSNorm, RoPE, LayerNorm, Conv3d | Swapping individual operators |
+| `references/parallelism-guide.md` | CFG/Ulysses/Ring/TP/FSDP/VAE parallel setup | Multi-device inference or training |
+| `references/quantization-guide.md` | mindiesd quantization config and FSDP integration | Deploying quantized models |

--- a/ascend-diffusion-adapt/evals/evals.json
+++ b/ascend-diffusion-adapt/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "ascend-diffusion-adapt",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I have a Stable Diffusion XL pipeline that works on CUDA with flash_attn. I need to port it to run on our Huawei Ascend 910B cluster with 8 NPUs. The model uses flash_attn_func for self-attention and flash_attn_varlen_func for cross-attention with T5 text encoder. Walk me through the full migration plan and show me the attention replacement code.",
+      "expected_output": "Should provide: 1) Device migration steps (cuda→npu, nccl→hccl, compilation flags), 2) Complete attention replacement code with mindiesd/torch_npu tiered fallback, 3) Both standard and varlen attention replacements, 4) bf16 casting for attention, 5) Multi-NPU setup with at minimum FSDP and CFG parallelism for 8 devices, 6) Environment variable dispatch pattern",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "I'm adapting a video generation model (similar to CogVideoX) for Ascend NPU. It uses CausalConv3d layers, RMSNorm, and rotary position embeddings. The model is about 12B parameters and I need to run inference on 4 Ascend 910B cards. What operator replacements should I make and how do I set up the distributed inference?",
+      "expected_output": "Should provide: 1) CausalConv3d padding optimization (spatial→kernel), 2) RMSNorm replacement with torch_npu.npu_rms_norm, 3) RoPE replacement with mindiesd.rotary_position_embedding or torch_npu.npu_apply_rotary_pos_emb, 4) Pre-computed cos/sin decomposition for RoPE, 5) 4-device parallel config (e.g., cfg_size=2 x ulysses_size=2), 6) FSDP setup with HCCL backend, 7) Warmup steps and compilation flags",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "We need to quantize our DiT (Diffusion Transformer) model for Ascend deployment to reduce memory usage. The model currently uses 30GB in bf16 and we need it to fit on a single 910B with 64GB HBM while leaving room for KV cache and activations. Also, can we use attention caching to speed up the 50-step denoising?",
+      "expected_output": "Should provide: 1) mindiesd.quantize() usage with W8A8 config, 2) Quant config JSON format with per-layer specifications, 3) Sensitive layer exclusion (time embedding, final projection), 4) FSDP + quantization integration with float8 buffer patching, 5) Attention caching setup with CacheConfig/CacheAgent, 6) Recommended caching parameters (ratio, start/end step, interval), 7) Memory estimation showing ~15GB for W8A8 quantized model",
+      "files": []
+    }
+  ]
+}

--- a/ascend-diffusion-adapt/references/attention-patterns.md
+++ b/ascend-diffusion-adapt/references/attention-patterns.md
@@ -1,0 +1,412 @@
+# Attention Replacement Patterns: CUDA → Ascend NPU
+
+Complete code patterns for replacing CUDA attention implementations with Ascend-native alternatives.
+
+## Table of Contents
+1. [Overview: Attention Tier System](#1-overview-attention-tier-system)
+2. [Replacing flash_attn Standard Attention](#2-replacing-flash_attn-standard-attention)
+3. [Replacing flash_attn_varlen_func](#3-replacing-flash_attn_varlen_func)
+4. [mindiesd Attention Algorithms](#4-mindiesd-attention-algorithms)
+5. [torch_npu Native Attention](#5-torch_npu-native-attention)
+6. [Environment Variable Dispatch](#6-environment-variable-dispatch)
+7. [Dtype Handling](#7-dtype-handling)
+8. [Sequence Parallel Attention](#8-sequence-parallel-attention)
+9. [Sparse Attention (Advanced)](#9-sparse-attention-advanced)
+
+---
+
+## 1. Overview: Attention Tier System
+
+Ascend supports multiple attention backends. Use this priority order:
+
+```
+Tier 1: attention_forward (from mindiesd)    — Fastest, requires mindiesd package
+Tier 2: torch_npu.npu_fused_infer_attention_score — Native NPU op, no extra deps
+Tier 3: torch.nn.functional.scaled_dot_product_attention — Portable fallback
+```
+
+In practice, wrap all three in a dispatcher function and select via env var:
+
+```python
+import os
+ALGO = int(os.environ.get("ALGO", "0"))
+
+def attention_op(q, k, v, mask=None):
+    if ALGO == 0:
+        return _mindiesd_attention(q, k, v)
+    elif ALGO == 3:
+        return _npu_fused_attention(q, k, v, mask)
+    else:
+        return F.scaled_dot_product_attention(q, k, v, attn_mask=mask)
+```
+
+---
+
+## 2. Replacing flash_attn Standard Attention
+
+### Original CUDA Code
+```python
+from flash_attn import flash_attn_func
+
+# q, k, v: [batch, seq_len, num_heads, head_dim]
+output = flash_attn_func(q, k, v, causal=False)
+```
+
+### Ascend Replacement
+```python
+from mindiesd import attention_forward
+
+def ascend_attention(q, k, v):
+    """
+    Replace flash_attn_func with mindiesd attention_forward.
+    
+    Input shapes:  q, k, v: [batch, seq_len, num_heads, head_dim]
+    Output shape:  [batch, seq_len, num_heads, head_dim]
+    
+    NOTE: attention_forward does NOT accept a scale parameter.
+    Scale is handled internally. It uses keyword args:
+      opt_mode, op_type, layout
+    """
+    # Cast to bfloat16 — Ascend attention is optimized for bf16
+    orig_dtype = q.dtype
+    q = q.to(torch.bfloat16)
+    k = k.to(torch.bfloat16)
+    v = v.to(torch.bfloat16)
+    
+    # Transpose to [batch, num_heads, seq_len, head_dim] — BNSD layout
+    q = q.transpose(1, 2)
+    k = k.transpose(1, 2)
+    v = v.transpose(1, 2)
+    
+    output = attention_forward(q, k, v, opt_mode="manual", op_type="fused_attn_score", layout="BNSD")
+    
+    # Transpose back to [batch, seq_len, num_heads, head_dim]
+    output = output.transpose(1, 2).to(orig_dtype)
+    return output
+```
+
+---
+
+## 3. Replacing flash_attn_varlen_func
+
+Variable-length attention (used for packed sequences) requires more care.
+
+### Original CUDA Code
+```python
+from flash_attn import flash_attn_varlen_func
+
+# q, k, v: [total_tokens, num_heads, head_dim]
+# cu_seqlens_q, cu_seqlens_k: cumulative sequence lengths
+# max_seqlen_q, max_seqlen_k: maximum sequence lengths
+output = flash_attn_varlen_func(
+    q, k, v,
+    cu_seqlens_q, cu_seqlens_k,
+    max_seqlen_q, max_seqlen_k,
+    causal=False
+)
+```
+
+### Ascend Replacement Strategy
+
+On Ascend, there's no direct `varlen` equivalent in mindiesd. Two approaches:
+
+**Approach A: Unpack to padded batch, run standard attention, repack**
+```python
+def varlen_attention_ascend(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k):
+    """
+    Simulate varlen attention by unpacking to padded sequences.
+    """
+    batch_size = len(cu_seqlens_q) - 1
+    
+    # Unpack to [batch, max_seq, heads, dim]
+    q_padded = torch.zeros(batch_size, max_seqlen_q, q.shape[1], q.shape[2], 
+                          dtype=q.dtype, device=q.device)
+    k_padded = torch.zeros(batch_size, max_seqlen_k, k.shape[1], k.shape[2],
+                          dtype=k.dtype, device=k.device)
+    v_padded = torch.zeros_like(k_padded)
+    
+    for i in range(batch_size):
+        sq = cu_seqlens_q[i+1] - cu_seqlens_q[i]
+        sk = cu_seqlens_k[i+1] - cu_seqlens_k[i]
+        q_padded[i, :sq] = q[cu_seqlens_q[i]:cu_seqlens_q[i+1]]
+        k_padded[i, :sk] = k[cu_seqlens_k[i]:cu_seqlens_k[i+1]]
+        v_padded[i, :sk] = v[cu_seqlens_k[i]:cu_seqlens_k[i+1]]
+    
+    # Run standard attention
+    out = attention_forward(q_padded, k_padded, v_padded)
+    
+    # Repack
+    output = torch.zeros_like(q)
+    for i in range(batch_size):
+        sq = cu_seqlens_q[i+1] - cu_seqlens_q[i]
+        output[cu_seqlens_q[i]:cu_seqlens_q[i+1]] = out[i, :sq]
+    
+    return output
+```
+
+**Approach B: Single-sequence loop (simpler, slower)**
+```python
+def varlen_attention_loop(q, k, v, cu_seqlens_q, cu_seqlens_k, max_seqlen_q, max_seqlen_k):
+    batch_size = len(cu_seqlens_q) - 1
+    output = torch.zeros_like(q)
+    
+    for i in range(batch_size):
+        q_i = q[cu_seqlens_q[i]:cu_seqlens_q[i+1]].unsqueeze(0)
+        k_i = k[cu_seqlens_k[i]:cu_seqlens_k[i+1]].unsqueeze(0)
+        v_i = v[cu_seqlens_k[i]:cu_seqlens_k[i+1]].unsqueeze(0)
+        out_i = attention_forward(q_i, k_i, v_i)
+        output[cu_seqlens_q[i]:cu_seqlens_q[i+1]] = out_i.squeeze(0)
+    
+    return output
+```
+
+Approach A is faster for large batches; Approach B is simpler and sufficient for inference with batch_size=1.
+
+---
+
+## 4. mindiesd Attention Algorithms
+
+mindiesd supports multiple algorithms via the `ALGO` environment variable:
+
+### ALGO=0: fused_attn_score (Default)
+```python
+from mindiesd import attention_forward
+
+# General-purpose fused attention
+# q, k, v: [batch, num_heads, seq_len, head_dim] — BNSD layout
+output = attention_forward(q, k, v, opt_mode="manual", op_type="fused_attn_score", layout="BNSD")
+```
+Best for: Most attention patterns, good balance of speed and precision.
+
+### ALGO=1: ascend_laser_attention
+```python
+from mindiesd import attention_forward
+
+# Laser attention — optimized for long sequences
+# Uses op_type="ascend_laser_attention", NOT an algo= parameter
+output = attention_forward(q, k, v, opt_mode="manual", op_type="ascend_laser_attention", layout="BNSD")
+```
+Best for: Long sequence lengths (>4K tokens), video models.
+
+### ALGO=3: npu_fused_infer_attention_score (torch_npu native)
+```python
+# Bypass mindiesd, use torch_npu directly
+output = torch_npu.npu_fused_infer_attention_score(
+    q, k, v,
+    num_heads=q.shape[1],
+    input_layout="BNSD",  # [batch, num_heads, seq, dim]
+    scale=scale,
+    pre_tokens=65535,
+    next_tokens=65535,
+)
+```
+Best for: When mindiesd is unavailable, or for specific operator fusion patterns.
+
+---
+
+## 5. torch_npu Native Attention
+
+When mindiesd is not installed, use torch_npu directly:
+
+```python
+import torch_npu
+
+def npu_attention(q, k, v, scale=None):
+    """
+    Native NPU fused attention without mindiesd dependency.
+    q, k, v: [batch, num_heads, seq_len, head_dim]
+    """
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    
+    output = torch_npu.npu_fused_infer_attention_score(
+        q, k, v,
+        num_heads=q.shape[1],
+        input_layout="BNSD",
+        scale=scale,
+        pre_tokens=65535,
+        next_tokens=65535,
+    )
+    return output
+```
+
+---
+
+## 6. Environment Variable Dispatch
+
+The recommended pattern for production: runtime-configurable attention backend.
+
+```python
+import os
+import torch
+import torch.nn.functional as F
+
+ALGO = int(os.environ.get("ALGO", "0"))
+
+try:
+    from mindiesd import attention_forward as mindiesd_attention_forward
+    HAS_MINDIESD = True
+except ImportError:
+    HAS_MINDIESD = False
+
+try:
+    import torch_npu
+    HAS_TORCH_NPU = True
+except ImportError:
+    HAS_TORCH_NPU = False
+
+
+def attention_op(q, k, v, mask=None):
+    """
+    Universal attention dispatcher for Ascend NPU.
+    
+    Args:
+        q, k, v: [batch, num_heads, seq_len, head_dim] — BNSD layout
+        mask: Optional attention mask
+    
+    NOTE: mindiesd.attention_forward does NOT accept a scale parameter.
+    Scale is computed internally. Do not pass scale=... to it.
+    For torch_npu and F.sdpa, scale can be passed separately.
+    """
+    scale = q.shape[-1] ** -0.5
+    
+    # Always cast to bf16 for attention on Ascend
+    orig_dtype = q.dtype
+    q = q.to(torch.bfloat16)
+    k = k.to(torch.bfloat16)
+    v = v.to(torch.bfloat16)
+    
+    if ALGO == 0 and HAS_MINDIESD:
+        output = mindiesd_attention_forward(q, k, v, opt_mode="manual", op_type="fused_attn_score", layout="BNSD")
+    elif ALGO == 1 and HAS_MINDIESD:
+        output = mindiesd_attention_forward(q, k, v, opt_mode="manual", op_type="ascend_laser_attention", layout="BNSD")
+    elif ALGO == 3 and HAS_TORCH_NPU:
+        output = torch_npu.npu_fused_infer_attention_score(
+            q, k, v,
+            num_heads=q.shape[1],
+            input_layout="BNSD",
+            scale=scale,
+            pre_tokens=65535,
+            next_tokens=65535,
+        )
+    else:
+        output = F.scaled_dot_product_attention(
+            q, k, v, attn_mask=mask, scale=scale
+        )
+    
+    return output.to(orig_dtype)
+```
+
+---
+
+## 7. Dtype Handling
+
+Ascend attention has specific dtype requirements:
+
+```python
+# CRITICAL: Always cast to bfloat16 for attention
+# fp16 has known precision issues on Ascend 910B for attention operations
+# fp32 works but is much slower
+
+original_dtype = hidden_states.dtype
+q = q.to(torch.bfloat16)
+k = k.to(torch.bfloat16)
+v = v.to(torch.bfloat16)
+
+output = attention_op(q, k, v)
+
+# Cast back to original dtype for downstream ops
+output = output.to(original_dtype)
+```
+
+---
+
+## 8. Sequence Parallel Attention
+
+When using Ulysses or Ring sequence parallelism, attention needs special handling:
+
+```python
+from yunchang import UlyssesAttention, set_seq_parallel_pg
+
+# Initialize sequence parallel group
+set_seq_parallel_pg(sp_group)
+
+# Wrap attention for sequence parallelism
+ulysses_attn = UlyssesAttention()
+
+# In forward:
+# q, k, v are already split along sequence dimension by SP
+output = ulysses_attn(
+    q, k, v,
+    joint_tensor_key=k if cross_attn else None,
+    joint_tensor_value=v if cross_attn else None,
+)
+```
+
+For Ring attention:
+```python
+from yunchang import LongContextAttention
+
+ring_attn = LongContextAttention(ring_impl_type="zigzag")
+output = ring_attn(q, k, v)
+```
+
+---
+
+## 9. Sparse Attention (Advanced)
+
+For video models with very long sequences (>16K tokens), sparse attention can skip computation:
+
+### Grid-Based Sparsity (Rainfusion v1)
+```python
+def create_grid_mask(height, width, num_frames, sparsity_ratio=0.5):
+    """
+    Create a grid-based attention mask that samples tokens
+    at regular intervals. Used in early denoising steps where
+    fine-grained attention is less important.
+    """
+    total = height * width * num_frames
+    keep = int(total * (1 - sparsity_ratio))
+    
+    # Sample on a regular spatial grid
+    step_h = max(1, int(height / (keep / num_frames) ** 0.5))
+    step_w = max(1, int(width / (keep / num_frames) ** 0.5))
+    
+    mask = torch.zeros(num_frames, height, width, dtype=torch.bool)
+    mask[:, ::step_h, ::step_w] = True
+    
+    return mask.reshape(-1)
+```
+
+### Blockwise Sparsity (Rainfusion v2)
+```python
+def blockwise_sparse_attention(q, k, v, block_size=256, threshold=0.1):
+    """
+    Skip attention blocks where the estimated attention score
+    is below threshold. More adaptive than grid-based.
+    """
+    seq_len = q.shape[2]
+    num_blocks = (seq_len + block_size - 1) // block_size
+    
+    # Estimate block importance via mean query-key dot product
+    outputs = []
+    for b in range(num_blocks):
+        start = b * block_size
+        end = min(start + block_size, seq_len)
+        q_block = q[:, :, start:end]
+        
+        # Quick importance estimate
+        importance = (q_block.mean(dim=2, keepdim=True) @ k.mean(dim=2, keepdim=True).transpose(-1, -2)).abs().mean()
+        
+        if importance > threshold:
+            out_block = attention_op(q_block, k, v)
+        else:
+            # Skip: use previous block's output or zero
+            out_block = torch.zeros_like(q_block)
+        
+        outputs.append(out_block)
+    
+    return torch.cat(outputs, dim=2)
+```
+
+Sparse attention is model-specific. Tune `sparsity_ratio` and `threshold` per model. Start with no sparsity and add gradually while monitoring output quality.

--- a/ascend-diffusion-adapt/references/device-migration-checklist.md
+++ b/ascend-diffusion-adapt/references/device-migration-checklist.md
@@ -1,0 +1,276 @@
+# Device Migration Checklist: CUDA → Ascend NPU
+
+Exhaustive find-and-replace patterns for migrating PyTorch code from CUDA to Ascend NPU.
+
+## Table of Contents
+1. [Imports](#1-imports)
+2. [Device Strings](#2-device-strings)
+3. [Distributed Backend](#3-distributed-backend)
+4. [AMP / Autocast](#4-amp--autocast)
+5. [Device Checks](#5-device-checks)
+6. [Compilation & Format](#6-compilation--format)
+7. [Stream & Synchronization](#7-stream--synchronization)
+8. [Memory Management](#8-memory-management)
+9. [Device Properties](#9-device-properties)
+
+---
+
+## 1. Imports
+
+Add at the top of every entry point (train.py, generate.py, etc.):
+
+```python
+import torch
+import torch_npu
+
+# Option A: Monkey-patch (quick migration)
+from torch_npu.contrib import transfer_to_npu
+# After this, most torch.cuda.* calls route to NPU automatically
+
+# Option B: Explicit (production)
+# No monkey-patch — replace all references manually
+```
+
+If using monkey-patch, you still need to fix items in sections 3-6 below.
+
+---
+
+## 2. Device Strings
+
+### Simple replacements
+```python
+# Before                              # After
+torch.device("cuda")                  torch.device("npu")
+torch.device("cuda:0")               torch.device("npu:0")
+torch.device(f"cuda:{rank}")         torch.device(f"npu:{rank}")
+.to("cuda")                          .to("npu")
+.cuda()                              .npu()
+```
+
+### With transfer_to_npu
+If using monkey-patch, most of these are handled automatically. But explicit `torch.device("cuda:N")` in configs or hardcoded device maps still need fixing.
+
+### Device map patterns (HuggingFace models)
+```python
+# Before
+model = AutoModel.from_pretrained(path, device_map="auto")
+# The "auto" device map works with transfer_to_npu
+
+# Before — explicit cuda device map
+device_map = {"encoder": "cuda:0", "decoder": "cuda:1"}
+# After
+device_map = {"encoder": "npu:0", "decoder": "npu:1"}
+```
+
+---
+
+## 3. Distributed Backend
+
+This is NOT handled by transfer_to_npu — always fix manually.
+
+```python
+# Before
+dist.init_process_group(backend="nccl")
+torch.distributed.init_process_group("nccl")
+
+# After
+dist.init_process_group(backend="hccl")
+torch.distributed.init_process_group("hccl")
+```
+
+Environment variables:
+```bash
+# Before
+export NCCL_DEBUG=INFO
+export NCCL_SOCKET_IFNAME=eth0
+
+# After
+export HCCL_CONNECT_TIMEOUT=1800
+export HCCL_EXEC_TIMEOUT=1800
+# HCCL uses different env vars — check CANN docs for your version
+```
+
+---
+
+## 4. AMP / Autocast
+
+```python
+# Before
+with torch.amp.autocast('cuda', dtype=torch.bfloat16):
+with torch.cuda.amp.autocast():
+with torch.autocast(device_type='cuda'):
+
+# After
+with torch.amp.autocast('npu', dtype=torch.bfloat16):
+with torch.npu.amp.autocast():
+with torch.autocast(device_type='npu'):
+```
+
+GradScaler:
+```python
+# Before
+scaler = torch.cuda.amp.GradScaler()
+scaler = torch.amp.GradScaler('cuda')
+
+# After
+scaler = torch.npu.amp.GradScaler()
+scaler = torch.amp.GradScaler('npu')
+```
+
+---
+
+## 5. Device Checks
+
+```python
+# Before
+if tensor.device.type == 'cuda':
+if str(device) == 'cuda':
+if torch.cuda.is_available():
+
+# After
+if tensor.device.type == 'npu':
+if str(device) == 'npu':
+if torch.npu.is_available():
+```
+
+### CPU offload patterns (Diffusers)
+```python
+# Diffusers enable_model_cpu_offload checks device type internally
+# If using transfer_to_npu, patch the check:
+if hasattr(self, '_offload_gpu_id'):
+    # Diffusers checks for 'cuda' — may need patching
+    pass
+```
+
+---
+
+## 6. Compilation & Format
+
+Add near the top of your entry point, BEFORE model creation:
+
+```python
+import torch_npu
+
+# Disable JIT compilation — critical for iterative denoising
+torch_npu.npu.set_compile_mode(jit_compile=False)
+
+# Force standard tensor format — prevents operator incompatibility
+torch.npu.config.allow_internal_format = False
+```
+
+Why `jit_compile=False`:
+- NPU JIT compiles operator graphs on first execution
+- Diffusion denoising loops have varying shapes/conditions per step
+- JIT recompilation per step destroys performance
+- Disabling JIT uses pre-compiled operator kernels instead
+
+Why `allow_internal_format=False`:
+- NPU has internal tensor formats optimized for specific operators
+- When mixing torch_npu ops with mindiesd ops, format mismatches cause silent errors
+- Forcing standard format ensures all operators see the same memory layout
+
+---
+
+## 7. Stream & Synchronization
+
+```python
+# Before
+torch.cuda.synchronize()
+torch.cuda.synchronize(device)
+stream = torch.cuda.Stream()
+with torch.cuda.stream(stream):
+torch.cuda.current_stream()
+
+# After
+torch.npu.synchronize()
+torch.npu.synchronize(device)
+stream = torch.npu.Stream()
+with torch.npu.stream(stream):
+torch.npu.current_stream()
+```
+
+### Timing pattern
+```python
+# Before
+torch.cuda.synchronize()
+start = time.time()
+# ... work ...
+torch.cuda.synchronize()
+elapsed = time.time() - start
+
+# After (identical structure, different API)
+torch.npu.synchronize()
+start = time.time()
+# ... work ...
+torch.npu.synchronize()
+elapsed = time.time() - start
+```
+
+---
+
+## 8. Memory Management
+
+```python
+# Before
+torch.cuda.empty_cache()
+torch.cuda.memory_allocated()
+torch.cuda.max_memory_allocated()
+torch.cuda.reset_peak_memory_stats()
+torch.cuda.memory_reserved()
+
+# After
+torch.npu.empty_cache()
+torch.npu.memory_allocated()
+torch.npu.max_memory_allocated()
+torch.npu.reset_peak_memory_stats()
+torch.npu.memory_reserved()
+```
+
+---
+
+## 9. Device Properties
+
+```python
+# Before
+torch.cuda.device_count()
+torch.cuda.get_device_name(0)
+torch.cuda.get_device_properties(0)
+torch.cuda.set_device(rank)
+
+# After
+torch.npu.device_count()
+torch.npu.get_device_name(0)
+torch.npu.get_device_properties(0)
+torch.npu.set_device(rank)
+```
+
+### Hardware detection pattern
+```python
+# Detect specific Ascend chip generation
+device_name = torch_npu.npu.get_device_name(0)
+is_910b = '95' in device_name   # Ascend 910B contains "95" in device name
+is_910c = '910C' in device_name or '100' in device_name  # Check your CANN docs
+```
+
+This is useful for enabling/disabling features that work only on certain generations.
+
+---
+
+## Checklist Summary
+
+Use this as a grep/sed list:
+
+| Find | Replace | Auto-handled by transfer_to_npu? |
+|------|---------|----------------------------------|
+| `"cuda"` (device string) | `"npu"` | Yes (mostly) |
+| `.cuda()` | `.npu()` | Yes |
+| `"nccl"` (dist backend) | `"hccl"` | **No** |
+| `torch.cuda.amp` | `torch.npu.amp` | Partial |
+| `torch.amp.autocast('cuda')` | `torch.amp.autocast('npu')` | **No** |
+| `device.type == 'cuda'` | `device.type == 'npu'` | **No** |
+| `torch.cuda.synchronize` | `torch.npu.synchronize` | Yes |
+| `torch.cuda.Stream` | `torch.npu.Stream` | Yes |
+| `torch.cuda.empty_cache` | `torch.npu.empty_cache` | Yes |
+| `torch.cuda.device_count` | `torch.npu.device_count` | Yes |
+| `flash_attn` imports | Remove / replace | **No** |
+| `xformers` imports | Remove / replace | **No** |

--- a/ascend-diffusion-adapt/references/operator-replacement.md
+++ b/ascend-diffusion-adapt/references/operator-replacement.md
@@ -1,0 +1,278 @@
+# Operator Replacement Guide: Fused NPU Kernels
+
+Before/after code for replacing standard PyTorch operators with Ascend-optimized fused kernels.
+
+## Table of Contents
+1. [RMSNorm](#1-rmsnorm)
+2. [LayerNorm](#2-layernorm)
+3. [Rotary Position Embedding (RoPE)](#3-rotary-position-embedding-rope)
+4. [CausalConv3d Padding](#4-causalconv3d-padding)
+5. [SiLU/GELU Activation](#5-silugelu-activation)
+6. [Summary Table](#6-summary-table)
+
+---
+
+## 1. RMSNorm
+
+RMSNorm is used extensively in DiT (Diffusion Transformers) and modern UNet architectures. The fused NPU kernel avoids materializing intermediate tensors.
+
+### Original (Manual Computation)
+```python
+class RMSNorm(nn.Module):
+    def __init__(self, dim, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x):
+        # Manual computation — 3 separate ops
+        norm = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+        return x * norm * self.weight
+```
+
+### Ascend Replacement
+```python
+import torch_npu
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+
+    def forward(self, x):
+        # Single fused kernel — no intermediate tensors
+        output, _ = torch_npu.npu_rms_norm(x, self.weight, epsilon=self.eps)
+        return output
+```
+
+**Note:** `npu_rms_norm` returns a tuple `(output, inverse_rms)`. The second value is only needed for backward pass in training; discard it during inference.
+
+### Conditional Pattern (Supporting Both Backends)
+```python
+import os
+
+try:
+    import torch_npu
+    HAS_NPU = True
+except ImportError:
+    HAS_NPU = False
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim, eps=1e-6):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(dim))
+        self.eps = eps
+        self.use_npu = HAS_NPU and torch.npu.is_available()
+
+    def forward(self, x):
+        if self.use_npu:
+            output, _ = torch_npu.npu_rms_norm(x, self.weight, epsilon=self.eps)
+            return output
+        else:
+            norm = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+            return x * norm * self.weight
+```
+
+---
+
+## 2. LayerNorm
+
+### Original
+```python
+output = F.layer_norm(x, normalized_shape, weight, bias, eps)
+# or
+layer_norm = nn.LayerNorm(hidden_size, eps=1e-6)
+output = layer_norm(x)
+```
+
+### Ascend Replacement (mindiesd fast_layernorm)
+```python
+import os
+FAST_LN = int(os.environ.get("FAST_LAYERNORM", "0"))
+
+if FAST_LN:
+    from mindiesd import fast_layernorm
+    # fast_layernorm takes (nn.Module, tensor) — NOT separate weight/bias/eps
+    # Pass the LayerNorm module itself as the first argument
+    output = fast_layernorm(self.norm1, x)
+else:
+    output = self.norm1(x)  # Standard nn.LayerNorm forward
+```
+
+**IMPORTANT**: `fast_layernorm` signature is `fast_layernorm(norm_module, x)` where `norm_module` is an `nn.LayerNorm` instance. It extracts weight, bias, and eps from the module internally. Do NOT pass weight/bias/eps as separate arguments.
+
+The mindiesd `fast_layernorm` is particularly beneficial for large hidden dimensions (>2048) where the standard LayerNorm becomes memory-bandwidth-bound.
+
+---
+
+## 3. Rotary Position Embedding (RoPE)
+
+RoPE is critical for DiT architectures and modern transformer-based diffusion models (FLUX, SD3, Wan2.x). The CUDA version typically uses complex number multiplication; the Ascend version uses fused kernels.
+
+### Original (Complex Number Application)
+```python
+def apply_rotary_emb(x, freqs):
+    """
+    x: [batch, seq, heads, dim]
+    freqs: [seq, dim//2, 2]  (cos, sin pairs)
+    """
+    # Reshape x to complex
+    x_complex = torch.view_as_complex(x.float().reshape(*x.shape[:-1], -1, 2))
+    freqs_complex = torch.view_as_complex(freqs)
+    
+    # Apply rotation
+    x_rotated = x_complex * freqs_complex
+    
+    # Back to real
+    return torch.view_as_real(x_rotated).reshape(*x.shape).type_as(x)
+```
+
+### Ascend Replacement Option A: mindiesd
+```python
+from mindiesd import rotary_position_embedding
+
+def apply_rotary_emb(x, freqs_cos, freqs_sin):
+    """
+    mindiesd RoPE uses pre-decomposed cos/sin.
+    
+    x: [batch, seq, heads, dim]
+    freqs_cos: [seq, dim]
+    freqs_sin: [seq, dim]
+    
+    NOTE: Uses rotated_mode= (string kwarg), NOT rotated_interleaved= (bool).
+    Also requires fused=True for the fused kernel path.
+    """
+    return rotary_position_embedding(
+        x, freqs_cos, freqs_sin,
+        rotated_mode="rotated_interleaved",
+        fused=True
+    )
+```
+
+### Ascend Replacement Option B: torch_npu
+```python
+import torch_npu
+
+def apply_rotary_emb(x, freqs_cos, freqs_sin):
+    """
+    torch_npu native RoPE.
+    
+    x: [batch, seq, heads, dim]
+    freqs_cos: [1, seq, 1, dim]  
+    freqs_sin: [1, seq, 1, dim]
+    """
+    return torch_npu.npu_apply_rotary_pos_emb(
+        x, freqs_cos, freqs_sin
+    )
+```
+
+### Pre-Computing cos/sin Decomposition
+
+The original code often stores RoPE frequencies as complex numbers. For Ascend, pre-decompose:
+
+```python
+class RoPEFreqs:
+    def __init__(self, dim, max_seq_len=8192, theta=10000.0):
+        freqs = 1.0 / (theta ** (torch.arange(0, dim, 2).float() / dim))
+        t = torch.arange(max_seq_len)
+        angles = torch.outer(t, freqs)
+        
+        # Store cos/sin separately instead of complex
+        self.cos = angles.cos()  # [max_seq, dim//2]
+        self.sin = angles.sin()  # [max_seq, dim//2]
+    
+    def get(self, seq_len):
+        cos = self.cos[:seq_len]  # [seq, dim//2]
+        sin = self.sin[:seq_len]  # [seq, dim//2]
+        # Expand to full dim by repeating (interleaved pattern)
+        cos = cos.repeat(1, 2)  # [seq, dim]
+        sin = sin.repeat(1, 2)  # [seq, dim]
+        return cos, sin
+```
+
+### Environment Variable Dispatch
+```python
+ROPE_OPT = int(os.environ.get("ROPE_OPT", "0"))
+
+def apply_rotary_emb(x, freqs_cos, freqs_sin):
+    if ROPE_OPT == 0 and HAS_MINDIESD:
+        return rotary_position_embedding(x, freqs_cos, freqs_sin, rotated_mode="rotated_interleaved", fused=True)
+    elif ROPE_OPT == 1 and HAS_TORCH_NPU:
+        return torch_npu.npu_apply_rotary_pos_emb(x, freqs_cos.unsqueeze(0).unsqueeze(2), freqs_sin.unsqueeze(0).unsqueeze(2))
+    else:
+        # Fallback: manual application
+        x1, x2 = x[..., :x.shape[-1]//2], x[..., x.shape[-1]//2:]
+        return torch.cat([x1 * freqs_cos - x2 * freqs_sin, x2 * freqs_cos + x1 * freqs_sin], dim=-1)
+```
+
+---
+
+## 4. CausalConv3d Padding
+
+For video diffusion models using 3D causal convolutions. The optimization moves spatial padding into the Conv3d kernel itself.
+
+### Original
+```python
+class CausalConv3d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0):
+        super().__init__()
+        # All padding done manually via F.pad
+        self.conv = nn.Conv3d(in_channels, out_channels, kernel_size, 
+                             stride=stride, padding=(0, 0, 0))  # No built-in padding
+        self.temporal_padding = kernel_size[0] - 1
+        self.spatial_padding = (padding, padding, padding, padding)
+    
+    def forward(self, x):
+        # Pad: (spatial_w, spatial_w, spatial_h, spatial_h, temporal, 0)
+        x = F.pad(x, (*self.spatial_padding, self.temporal_padding, 0))
+        return self.conv(x)
+```
+
+### Ascend Optimized
+```python
+class CausalConv3d(nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0):
+        super().__init__()
+        # Spatial padding handled by Conv3d kernel (fused, faster)
+        self.conv = nn.Conv3d(in_channels, out_channels, kernel_size,
+                             stride=stride, padding=(0, padding, padding))
+        # Only temporal padding via F.pad
+        self.temporal_padding = kernel_size[0] - 1
+        self._pad = (0, 0, 0, 0, self.temporal_padding, 0)
+    
+    def forward(self, x):
+        # Only temporal dimension needs explicit padding
+        x = F.pad(x, self._pad)
+        return self.conv(x)
+```
+
+**Why this helps:** NPU convolution kernels are optimized for standard padding patterns. When spatial padding is part of the Conv3d spec, the kernel fuses padding with the convolution computation, eliminating a separate memory copy operation. Temporal padding (causal = pad only the past) cannot be expressed as standard Conv3d padding, so it remains as `F.pad`.
+
+---
+
+## 5. SiLU/GELU Activation
+
+Standard activations generally work fine on NPU without replacement. However, if profiling shows activation functions as bottlenecks:
+
+```python
+# torch_npu has optimized paths for standard activations
+# These are used automatically when tensors are on NPU
+x = F.silu(x)   # Automatically uses NPU-optimized kernel
+x = F.gelu(x)   # Automatically uses NPU-optimized kernel
+```
+
+No explicit replacement needed — `torch_npu` registers optimized kernels for standard PyTorch operations when tensors are on NPU device.
+
+---
+
+## 6. Summary Table
+
+| Operator | Original | Ascend Replacement | Env Var | Speedup |
+|----------|----------|-------------------|---------|---------|
+| RMSNorm | `torch.rsqrt(x.pow(2).mean(...))` | `torch_npu.npu_rms_norm(x, w)` | — | ~2x |
+| LayerNorm | `nn.LayerNorm(x)` | `fast_layernorm(norm_module, x)` | `FAST_LAYERNORM` | ~1.5x |
+| RoPE | Complex number multiplication | `rotary_position_embedding(x, cos, sin, rotated_mode=..., fused=True)` | `ROPE_OPT=0` | ~2x |
+| RoPE | Complex number multiplication | `torch_npu.npu_apply_rotary_pos_emb(...)` | `ROPE_OPT=1` | ~1.8x |
+| CausalConv3d | All padding via `F.pad` | Spatial padding in Conv3d kernel | — | ~1.3x |
+| Attention | `flash_attn_func(...)` | `attention_forward(q, k, v, opt_mode=..., op_type=..., layout=...)` | `ALGO` | ~1.5-3x |

--- a/ascend-diffusion-adapt/references/parallelism-guide.md
+++ b/ascend-diffusion-adapt/references/parallelism-guide.md
@@ -1,0 +1,417 @@
+# Distributed Parallelism Guide for Ascend Diffusion Models
+
+How to configure multi-NPU inference and training for diffusion models on Ascend.
+
+## Table of Contents
+1. [Parallelism Strategies Overview](#1-parallelism-strategies-overview)
+2. [CFG Parallelism](#2-cfg-parallelism)
+3. [Sequence Parallelism (Ulysses)](#3-sequence-parallelism-ulysses)
+4. [Ring Attention](#4-ring-attention)
+5. [Tensor Parallelism](#5-tensor-parallelism)
+6. [FSDP on Ascend](#6-fsdp-on-ascend)
+7. [VAE Patch Parallelism](#7-vae-patch-parallelism)
+8. [Composing Strategies](#8-composing-strategies)
+9. [Process Group Setup](#9-process-group-setup)
+
+---
+
+## 1. Parallelism Strategies Overview
+
+| Strategy | Parallelizes | Devices | Best For |
+|----------|-------------|---------|----------|
+| CFG Parallel | CFG branches | 2 | Any CFG inference (always use if available) |
+| Ulysses SP | Sequence dim | 2-8 | Video/long-sequence models |
+| Ring Attention | Sequence dim | 2-8 | Very long sequences, memory-limited |
+| Tensor Parallel | Weight matrices | 2-8 | Large models (>10B params) |
+| FSDP | Full model | any | Training, large-model inference |
+| VAE Patch | VAE spatial | 2-8 | High-resolution decode |
+
+**Composition rule:** Strategies are orthogonal.
+```
+total_devices = cfg_size × ulysses_size × ring_size × tp_size
+```
+
+---
+
+## 2. CFG Parallelism
+
+Classifier-Free Guidance runs the model twice per denoising step (conditional + unconditional). CFG parallelism splits these across 2 devices.
+
+### Standard CFG (Single Device)
+```python
+# Standard: two forward passes on one device
+noise_uncond = model(x, t, null_context)
+noise_cond = model(x, t, context)
+noise_pred = noise_uncond + guidance_scale * (noise_cond - noise_uncond)
+```
+
+### CFG Parallel (2 Devices)
+```python
+import torch.distributed as dist
+
+def cfg_parallel_forward(model, x, t, context, null_context, guidance_scale, cfg_group):
+    """
+    Each device runs ONE forward pass. Results combined via all_gather.
+    """
+    rank_in_cfg = dist.get_rank(cfg_group)
+    
+    if rank_in_cfg == 0:
+        # Device 0: unconditional
+        noise = model(x, t, null_context)
+    else:
+        # Device 1: conditional
+        noise = model(x, t, context)
+    
+    # Gather both results to all devices
+    gathered = [torch.zeros_like(noise) for _ in range(2)]
+    dist.all_gather(gathered, noise, group=cfg_group)
+    
+    noise_uncond, noise_cond = gathered[0], gathered[1]
+    return noise_uncond + guidance_scale * (noise_cond - noise_uncond)
+```
+
+**Benefits:** Halves per-device memory, nearly doubles throughput. The all_gather communication cost is small relative to the full model forward pass.
+
+---
+
+## 3. Sequence Parallelism (Ulysses)
+
+Splits the sequence dimension across devices. Each device holds a slice of the sequence and runs full attention within its slice, then communicates.
+
+### Setup
+```python
+from yunchang import set_seq_parallel_pg, UlyssesAttention
+
+# Create sequence parallel process group
+sp_group = dist.new_group(ranks=[0, 1, 2, 3])  # 4-way SP
+set_seq_parallel_pg(sp_group)
+
+# Wrap attention
+ulysses_attn = UlyssesAttention()
+```
+
+### Usage in Transformer Block
+```python
+class DiTBlock(nn.Module):
+    def __init__(self, ...):
+        self.ulysses_attn = UlyssesAttention()
+    
+    def forward(self, x, context=None):
+        # x is already split along sequence dim by the SP framework
+        q, k, v = self.to_qkv(x)
+        
+        if context is not None:
+            # Cross attention: gather full context
+            attn_out = self.ulysses_attn(
+                q, k, v,
+                joint_tensor_key=context_k,
+                joint_tensor_value=context_v,
+            )
+        else:
+            attn_out = self.ulysses_attn(q, k, v)
+        
+        return self.proj(attn_out)
+```
+
+### Input Splitting
+```python
+# Before the model forward, split input along sequence dim
+def split_sequence(x, sp_group):
+    """
+    x: [batch, seq_len, dim]
+    Returns: [batch, seq_len // sp_size, dim]
+    """
+    sp_size = dist.get_world_size(sp_group)
+    sp_rank = dist.get_rank(sp_group)
+    seq_len = x.shape[1]
+    chunk_size = seq_len // sp_size
+    return x[:, sp_rank * chunk_size:(sp_rank + 1) * chunk_size]
+```
+
+---
+
+## 4. Ring Attention
+
+Alternative to Ulysses for very long sequences. Each device holds a chunk of KV and rotates it ring-style.
+
+```python
+from yunchang import LongContextAttention
+
+ring_attn = LongContextAttention(ring_impl_type="zigzag")
+
+# In transformer block
+output = ring_attn(q, k, v)
+```
+
+Ring attention has higher communication cost than Ulysses but better memory scaling for very long sequences (>64K tokens).
+
+---
+
+## 5. Tensor Parallelism
+
+Splits weight matrices across devices. Each device computes a slice of the output, then all-reduces.
+
+### TensorParallelApplicator Pattern
+```python
+class TensorParallelApplicator:
+    """Applies tensor parallelism to model layers."""
+    
+    def __init__(self, tp_group):
+        self.tp_group = tp_group
+        self.tp_size = dist.get_world_size(tp_group)
+        self.tp_rank = dist.get_rank(tp_group)
+    
+    def parallelize_linear(self, module, name, style="column"):
+        """
+        Split a linear layer across TP group.
+        style="column": split output dim (for QKV projections)
+        style="row": split input dim (for output projections)
+        """
+        linear = getattr(module, name)
+        
+        if style == "column":
+            # Split weight along output dim
+            chunk_size = linear.out_features // self.tp_size
+            weight = linear.weight[self.tp_rank * chunk_size:(self.tp_rank + 1) * chunk_size]
+            bias = linear.bias[self.tp_rank * chunk_size:(self.tp_rank + 1) * chunk_size] if linear.bias is not None else None
+        elif style == "row":
+            # Split weight along input dim
+            chunk_size = linear.in_features // self.tp_size
+            weight = linear.weight[:, self.tp_rank * chunk_size:(self.tp_rank + 1) * chunk_size]
+            bias = linear.bias if self.tp_rank == 0 else None  # Only rank 0 adds bias
+        
+        new_linear = nn.Linear(weight.shape[1], weight.shape[0], bias=bias is not None)
+        new_linear.weight = nn.Parameter(weight)
+        if bias is not None:
+            new_linear.bias = nn.Parameter(bias)
+        
+        setattr(module, name, new_linear)
+```
+
+### Typical Application
+```python
+tp_applicator = TensorParallelApplicator(tp_group)
+
+for block in model.transformer_blocks:
+    # Column parallel for QKV
+    tp_applicator.parallelize_linear(block.attn, "to_q", "column")
+    tp_applicator.parallelize_linear(block.attn, "to_k", "column")
+    tp_applicator.parallelize_linear(block.attn, "to_v", "column")
+    # Row parallel for output projection
+    tp_applicator.parallelize_linear(block.attn, "to_out", "row")
+    # Column parallel for FFN first layer
+    tp_applicator.parallelize_linear(block.ffn, "fc1", "column")
+    # Row parallel for FFN second layer
+    tp_applicator.parallelize_linear(block.ffn, "fc2", "row")
+```
+
+---
+
+## 6. FSDP on Ascend
+
+FSDP (Fully Sharded Data Parallelism) works on Ascend with the HCCL backend. Key differences from CUDA:
+
+### Setup
+```python
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
+
+def shard_model(model, device_id, param_dtype=torch.bfloat16):
+    """
+    FSDP setup for Ascend NPU.
+    Note: use_orig_params is NOT used on Ascend.
+    """
+    mp_policy = MixedPrecision(
+        param_dtype=param_dtype,
+        reduce_dtype=torch.float32,
+        buffer_dtype=torch.float32,
+    )
+    
+    model = FSDP(
+        model,
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        mixed_precision=mp_policy,
+        device_id=device_id,
+        # Do NOT pass use_orig_params on Ascend
+        # Do NOT pass use_lora on Ascend
+    )
+    
+    return model
+```
+
+### FSDP + Quantization Compatibility
+
+When using quantized models with FSDP, float8 buffer types need patching:
+
+```python
+def patch_cast_buffers_for_float8(model):
+    """
+    FSDP's _cast_buffers doesn't handle float8 types.
+    Patch to skip casting for float8 buffers.
+    """
+    original_cast = FSDP._cast_buffers
+    
+    def patched_cast(self, *args, **kwargs):
+        # Filter out float8 buffers before casting
+        float8_buffers = {}
+        for name, buf in self.named_buffers():
+            if buf.dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+                float8_buffers[name] = buf
+        
+        original_cast(self, *args, **kwargs)
+        
+        # Restore float8 buffers
+        for name, buf in float8_buffers.items():
+            # Re-assign the original float8 buffer
+            parts = name.split('.')
+            module = self
+            for part in parts[:-1]:
+                module = getattr(module, part)
+            setattr(module, parts[-1], buf)
+    
+    FSDP._cast_buffers = patched_cast
+```
+
+---
+
+## 7. VAE Patch Parallelism
+
+For high-resolution output (e.g., 1080p video), VAE decode can OOM on a single device. Patch parallelism splits the latent spatially:
+
+```python
+class VAEPatchParallel:
+    """
+    Context manager that patches VAE forward to decode in spatial patches
+    distributed across devices.
+    """
+    
+    def __init__(self, vae, parallel_group, overlap=4):
+        self.vae = vae
+        self.group = parallel_group
+        self.world_size = dist.get_world_size(parallel_group)
+        self.rank = dist.get_rank(parallel_group)
+        self.overlap = overlap  # Overlap pixels to avoid seam artifacts
+    
+    def decode(self, latent):
+        """
+        latent: [batch, channels, frames, height, width] (for video)
+        or [batch, channels, height, width] (for image)
+        """
+        is_video = latent.dim() == 5
+        spatial_dim = -1  # Split along width
+        
+        total_size = latent.shape[spatial_dim]
+        chunk_size = total_size // self.world_size
+        
+        # Each device decodes its spatial chunk (with overlap)
+        start = max(0, self.rank * chunk_size - self.overlap)
+        end = min(total_size, (self.rank + 1) * chunk_size + self.overlap)
+        
+        if is_video:
+            chunk = latent[..., start:end]
+        else:
+            chunk = latent[..., start:end]
+        
+        # Decode locally
+        decoded_chunk = self.vae.decode(chunk)
+        
+        # Trim overlap
+        trim_start = self.overlap if self.rank > 0 else 0
+        trim_end = -self.overlap if self.rank < self.world_size - 1 else None
+        decoded_chunk = decoded_chunk[..., trim_start:trim_end]
+        
+        # Gather all chunks
+        all_chunks = [torch.zeros_like(decoded_chunk) for _ in range(self.world_size)]
+        dist.all_gather(all_chunks, decoded_chunk, group=self.group)
+        
+        return torch.cat(all_chunks, dim=spatial_dim)
+```
+
+---
+
+## 8. Composing Strategies
+
+### Example: 8-device Setup for Video Generation
+```
+8 NPUs total:
+- CFG parallel: 2 groups (conditional / unconditional)
+- Within each CFG group: 4-way Ulysses SP
+
+cfg_size = 2
+ulysses_size = 4
+total = 2 × 4 = 8 devices
+```
+
+### Process Group Creation
+```python
+def create_parallel_groups(world_size, cfg_size=1, ulysses_size=1, ring_size=1, tp_size=1):
+    """
+    Create orthogonal process groups for composed parallelism.
+    """
+    assert world_size == cfg_size * ulysses_size * ring_size * tp_size
+    
+    groups = {}
+    
+    # CFG groups: consecutive pairs
+    if cfg_size > 1:
+        for i in range(0, world_size, cfg_size):
+            ranks = list(range(i, i + cfg_size))
+            group = dist.new_group(ranks)
+            if dist.get_rank() in ranks:
+                groups['cfg'] = group
+    
+    # SP groups: within each CFG group
+    if ulysses_size > 1:
+        for cfg_id in range(world_size // (cfg_size * ulysses_size)):
+            base = cfg_id * cfg_size * ulysses_size
+            for cfg_rank in range(cfg_size):
+                ranks = [base + cfg_rank + i * cfg_size for i in range(ulysses_size)]
+                group = dist.new_group(ranks)
+                if dist.get_rank() in ranks:
+                    groups['sp'] = group
+    
+    return groups
+```
+
+---
+
+## 9. Process Group Setup
+
+### Full Initialization Pattern
+```python
+import torch
+import torch.distributed as dist
+import torch_npu
+
+def init_parallel_env(cfg_size=1, ulysses_size=1, ring_size=1, tp_size=1):
+    """
+    Initialize distributed environment for Ascend.
+    """
+    # Basic distributed setup
+    dist.init_process_group(backend="hccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    
+    # Set device
+    local_rank = rank % torch.npu.device_count()
+    torch.npu.set_device(local_rank)
+    
+    # Create parallel groups
+    groups = create_parallel_groups(world_size, cfg_size, ulysses_size, ring_size, tp_size)
+    
+    return rank, world_size, groups
+
+def finalize_parallel_env():
+    """Clean up distributed environment."""
+    dist.destroy_process_group()
+```
+
+### Launch Command
+```bash
+# 8-NPU launch
+torchrun --nproc_per_node=8 --master_port=29500 \
+    generate.py \
+    --cfg_size 2 \
+    --ulysses_size 4 \
+    --prompt "..."
+```

--- a/ascend-diffusion-adapt/references/quantization-guide.md
+++ b/ascend-diffusion-adapt/references/quantization-guide.md
@@ -1,0 +1,287 @@
+# Quantization Guide for Ascend Diffusion Models
+
+How to quantize diffusion models (DiT, UNet, VAE) for Ascend NPU deployment using mindiesd.
+
+## Table of Contents
+1. [Overview](#1-overview)
+2. [Supported Schemes](#2-supported-schemes)
+3. [Basic Quantization](#3-basic-quantization)
+4. [Quant Config File Format](#4-quant-config-file-format)
+5. [Config File Discovery](#5-config-file-discovery)
+6. [FSDP Integration](#6-fsdp-integration)
+7. [Quantized Attention](#7-quantized-attention)
+8. [CLI Integration](#8-cli-integration)
+
+---
+
+## 1. Overview
+
+mindiesd provides post-training quantization (PTQ) for diffusion models. The quantization flow:
+
+1. Prepare a quant description JSON (specifies per-layer quantization parameters)
+2. Discover the config file via `find_quant_config_file()` — returns `(path, use_nz)` tuple
+3. Call `quantize(model=model, quant_des_path=path, use_nz=use_nz)` to apply quantization
+4. Run inference as normal — quantized ops are transparent
+
+Quantization reduces memory usage and increases throughput, with minimal quality loss for well-calibrated configs.
+
+---
+
+## 2. Supported Schemes
+
+| Scheme | Description | Memory Savings | Quality Impact |
+|--------|-------------|---------------|----------------|
+| W8A8 (dynamic) | 8-bit weights, 8-bit activations | ~2x | Minimal |
+| W8A8 (MXFP8) | Microscaling FP8 format | ~2x | Minimal |
+| W4A8 | 4-bit weights, 8-bit activations | ~3x | Low-moderate |
+| W4A4 (MXFP4) | 4-bit weights, 4-bit activations, dual-scale | ~4x | Moderate |
+
+Start with W8A8 — it's the safest. Move to W4A8 only if memory is the bottleneck and you've verified quality.
+
+---
+
+## 3. Basic Quantization
+
+```python
+import torch
+from mindiesd import quantize
+
+# Load model normally
+model = load_your_diffusion_model(checkpoint_path)
+model = model.to("npu")
+
+# Discover quant config (returns tuple)
+quant_des_path, use_nz = find_quant_config_file(quant_dir)
+
+# Apply quantization
+# NOTE: parameter is quant_des_path (description path), NOT quant_config_path
+# use_nz controls NZ compression format (True for w8a8_dynamic, w4a4; False for mxfp8)
+quantize(model=model, quant_des_path=quant_des_path, use_nz=use_nz)
+
+# Inference as normal — quantized ops are transparent
+output = model(input_tensor)
+```
+
+The `quantize()` call:
+- Reads the description file to determine which layers to quantize and how
+- Replaces linear layers with quantized equivalents
+- Handles calibration internally if needed
+- Modifies the model in-place
+
+---
+
+## 4. Quant Config File Format
+
+The quant config JSON specifies per-layer quantization parameters:
+
+### W8A8 Dynamic Example
+```json
+{
+  "quant_type": "w8a8_dynamic",
+  "model_type": "dit",
+  "layers": {
+    "transformer_blocks.*.attn.to_q": {"weight_bits": 8, "act_bits": 8},
+    "transformer_blocks.*.attn.to_k": {"weight_bits": 8, "act_bits": 8},
+    "transformer_blocks.*.attn.to_v": {"weight_bits": 8, "act_bits": 8},
+    "transformer_blocks.*.attn.to_out": {"weight_bits": 8, "act_bits": 8},
+    "transformer_blocks.*.ffn.fc1": {"weight_bits": 8, "act_bits": 8},
+    "transformer_blocks.*.ffn.fc2": {"weight_bits": 8, "act_bits": 8}
+  },
+  "exclude_layers": [
+    "final_layer",
+    "time_embed"
+  ]
+}
+```
+
+### Key Config Fields
+- `quant_type`: One of `w8a8_dynamic`, `w8a8_mxfp8`, `w4a8`, `w4a4_mxfp4_dualscale`
+- `model_type`: Model architecture hint (`dit`, `unet`, `vae`)
+- `layers`: Glob patterns mapping layer names to quantization config
+- `exclude_layers`: Layers to keep in full precision (typically embedding, final projection, time embedding)
+
+### Sensitive Layers
+
+Some layers are sensitive to quantization and should be excluded:
+- **Time embedding** — Precision here affects all denoising steps
+- **Final projection** — Direct impact on output quality
+- **First/last transformer block** — Often more sensitive than middle blocks
+- **Cross-attention QKV** — Text conditioning is precision-sensitive
+
+---
+
+## 5. Config File Discovery
+
+The Ascend adaptation uses a utility to find quant configs. **Returns a `(path, use_nz)` tuple**, not just a path.
+
+```python
+import os
+
+def find_quant_config_file(quant_dit_path):
+    """
+    Search for quantization description files in the given directory.
+    
+    Returns:
+        tuple: (config_path: str, use_nz: bool)
+            - config_path: Full path to the quant description JSON
+            - use_nz: Whether to use NZ compression format
+    
+    Priority order (with corresponding use_nz values):
+    1. quant_model_description_w8a8_dynamic.json  → use_nz=True
+    2. quant_model_description_w8a8_mxfp8.json    → use_nz=False
+    3. quant_model_description_w4a4_mxfp4_dualscale.json → use_nz=True
+    """
+    candidates = [
+        ("quant_model_description_w8a8_dynamic.json", True),
+        ("quant_model_description_w8a8_mxfp8.json", False),
+        ("quant_model_description_w4a4_mxfp4_dualscale.json", True),
+    ]
+    
+    for name, use_nz in candidates:
+        path = os.path.join(quant_dit_path, name)
+        if os.path.exists(path):
+            return path, use_nz
+    
+    raise FileNotFoundError(
+        f"No quant config found in {quant_dit_path}. "
+        f"Expected one of: {[c[0] for c in candidates]}"
+    )
+```
+
+**IMPORTANT**: The file naming convention is `quant_model_description_<scheme>.json`. The `use_nz` flag varies by scheme — W8A8 dynamic and W4A4 use NZ format, while MXFP8 does not.
+
+---
+
+## 6. FSDP Integration
+
+When combining quantization with FSDP, float8 buffer types need special handling:
+
+```python
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from mindiesd import quantize
+
+def setup_quantized_fsdp_model(model, quant_des_path, use_nz, device_id):
+    """
+    Quantize first, then wrap with FSDP.
+    Order matters: quantize → FSDP, not the reverse.
+    """
+    # Step 1: Quantize (note: quant_des_path and use_nz, not quant_config_path)
+    quantize(model=model, quant_des_path=quant_des_path, use_nz=use_nz)
+    
+    # Step 2: Patch FSDP for float8 compatibility
+    patch_cast_buffers_for_float8(model)
+    
+    # Step 3: Wrap with FSDP
+    model = FSDP(
+        model,
+        device_id=device_id,
+        mixed_precision=MixedPrecision(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.float32,
+            buffer_dtype=torch.float32,
+        ),
+    )
+    
+    return model
+
+
+def patch_cast_buffers_for_float8(model):
+    """
+    FSDP's internal buffer casting doesn't handle float8 dtypes.
+    This patches _cast_buffers to skip float8 buffers.
+    """
+    float8_types = {torch.float8_e4m3fn, torch.float8_e5m2}
+    
+    original_cast = FSDP._cast_buffers
+    
+    def safe_cast(self, *args, **kwargs):
+        saved = {}
+        for name, buf in self.named_buffers():
+            if buf is not None and buf.dtype in float8_types:
+                saved[name] = buf.clone()
+        
+        original_cast(self, *args, **kwargs)
+        
+        for name, buf in saved.items():
+            parts = name.split('.')
+            mod = self
+            for p in parts[:-1]:
+                mod = getattr(mod, p)
+            setattr(mod, parts[-1], buf)
+    
+    FSDP._cast_buffers = safe_cast
+```
+
+---
+
+## 7. Quantized Attention
+
+mindiesd also supports quantized flash attention:
+
+```python
+# When model is quantized, attention can use quantized kernels
+class QuantizedAttention(nn.Module):
+    def __init__(self, dim, num_heads):
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.to_qkv = nn.Linear(dim, 3 * dim)
+        self.to_out = nn.Linear(dim, dim)
+        self.fa_quant = None  # Set by mindiesd.quantize() if applicable
+    
+    def forward(self, x):
+        qkv = self.to_qkv(x)
+        q, k, v = qkv.chunk(3, dim=-1)
+        q = q.reshape(*q.shape[:-1], self.num_heads, self.head_dim)
+        k = k.reshape(*k.shape[:-1], self.num_heads, self.head_dim)
+        v = v.reshape(*v.shape[:-1], self.num_heads, self.head_dim)
+        
+        if self.fa_quant is not None:
+            # Use quantized attention kernel
+            output = self.fa_quant(q, k, v)
+        else:
+            # Standard attention
+            output = attention_op(q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2))
+            output = output.transpose(1, 2)
+        
+        output = output.reshape(*output.shape[:-2], -1)
+        return self.to_out(output)
+```
+
+---
+
+## 8. CLI Integration
+
+Typical CLI pattern for enabling quantization:
+
+```python
+import argparse
+from mindiesd import quantize
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--quant_dit_path", type=str, default=None,
+                    help="Path to directory containing quant description JSON")
+
+args = parser.parse_args()
+
+# Load model
+model = load_model(checkpoint)
+
+# Optionally quantize
+if args.quant_dit_path:
+    quant_des_path, use_nz = find_quant_config_file(args.quant_dit_path)
+    quantize(model=model, quant_des_path=quant_des_path, use_nz=use_nz)
+    print(f"Model quantized with config: {quant_des_path} (use_nz={use_nz})")
+
+# Continue with FSDP, inference, etc.
+```
+
+### Running Quantized Inference
+```bash
+# W8A8 quantized inference
+torchrun --nproc_per_node=8 generate.py \
+    --quant_dit_path /path/to/quant_configs/ \
+    --cfg_size 2 \
+    --ulysses_size 4 \
+    --prompt "..."
+```


### PR DESCRIPTION
## Summary

新增 `ascend-diffusion-adapt` skill，提供从 CUDA/GPU 到华为昇腾 NPU 迁移 Diffusion 模型的完整指南。

该 skill 源自 Wan2.2 视频生成模型的实际适配经验，涵盖：
- **设备迁移**：CUDA→NPU 引用替换、NCCL→HCCL、编译标志
- **Attention 替换**：flash_attn/xformers → torch_npu/mindiesd 多级回退
- **算子替换**：RMSNorm、LayerNorm、RoPE、CausalConv3d 融合算子
- **分布式并行**：CFG/Ulysses/Ring/Tensor Parallelism/FSDP
- **VAE 优化**：Patch 并行解码、Tiling/Slicing
- **量化部署**：W8A8/W4A8 via mindiesd
- **Attention 缓存**：跳过冗余 attention 计算加速去噪
- **运行时调优**：Warmup、环境变量、精度控制

### 文件结构

```
ascend-diffusion-adapt/
├── SKILL.md                              # 核心内容（345行）
├── references/
│   ├── device-migration-checklist.md     # CUDA→NPU 完整替换清单
│   ├── attention-patterns.md             # Attention 替换代码模式
│   ├── operator-replacement.md           # 算子替换前后对照
│   ├── parallelism-guide.md              # 分布式并行配置指南
│   └── quantization-guide.md             # 量化配置与 FSDP 集成
└── evals/
    └── evals.json                        # 3 个评估用例
```

### 验证

- [x] `name` 与目录名一致
- [x] `description` ≥20 字符
- [x] 有效 YAML frontmatter
- [x] 已添加到 `marketplace.json`
- [x] 已添加到 `README.md` skill 列表
- [x] `python3 scripts/validate_skills.py` 通过（0 errors, 0 warnings）