### PR TITLE
fix(sync): Preserve external skills on resync

### DIFF
--- a/scripts/sync_external_skills.py
+++ b/scripts/sync_external_skills.py
@@ -8,7 +8,7 @@ import tempfile
 import yaml
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 script_dir = Path(__file__).parent
 project_root = script_dir.parent
@@ -252,19 +252,92 @@ def get_synced_skills() -> Set[str]:
     return skills
 
 
+def load_existing_external_skills(
+    sources: Iterable[ExternalSource], external_root: Union[Path, str] = "external"
+) -> Dict[Tuple[str, str], Tuple[Skill, str]]:
+    external_dir = Path(external_root)
+    existing_skills: Dict[Tuple[str, str], Tuple[Skill, str]] = {}
+    source_map = {source.name: source for source in sources if source.enabled}
+
+    if not external_dir.exists():
+        return existing_skills
+
+    for source_name, source in source_map.items():
+        source_dir = external_dir / source_name
+        if not source_dir.exists() or not source_dir.is_dir():
+            continue
+
+        for skill_dir in source_dir.iterdir():
+            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                continue
+
+            parsed = parse_skill_md(skill_dir)
+            commit_sha = str(parsed.get("synced-commit", ""))
+            source_url = str(parsed.get("synced-from", source.url))
+            existing_skills[(source_name, skill_dir.name)] = (
+                Skill(
+                    name=skill_dir.name,
+                    path=skill_dir,
+                    source=ExternalSource(
+                        name=source.name,
+                        url=source_url,
+                        branch=source.branch,
+                        enabled=source.enabled,
+                        skills_path=source.skills_path,
+                    ),
+                    has_skill_md=True,
+                ),
+                commit_sha,
+            )
+
+    return existing_skills
+
+
+def build_synced_skill_index(
+    synced_skills: Dict[Tuple[str, str], Tuple[Skill, str]]
+) -> Dict[str, Set[str]]:
+    index: Dict[str, Set[str]] = {}
+    for source_name, skill_name in synced_skills.keys():
+        index.setdefault(skill_name, set()).add(source_name)
+    return index
+
+
+def prune_removed_source_skills(
+    existing_skills: Dict[Tuple[str, str], Tuple[Skill, str]],
+    source: ExternalSource,
+    current_skill_names: Set[str],
+) -> None:
+    source_root = Path("external") / source.name
+    removed_keys = [
+        key
+        for key in existing_skills
+        if key[0] == source.name and key[1] not in current_skill_names
+    ]
+
+    for key in removed_keys:
+        skill_path = source_root / key[1]
+        if skill_path.exists():
+            shutil.rmtree(skill_path)
+        del existing_skills[key]
+
+    if source_root.exists() and not any(source_root.iterdir()):
+        source_root.rmdir()
+
+
 def detect_conflicts(
-    skill: Skill, local_skills: Set[str], synced_skills: Set[str]
+    skill: Skill, local_skills: Set[str], synced_skills: Dict[str, Set[str]]
 ) -> Optional[ConflictInfo]:
     """Check if skill conflicts with local or synced skills."""
     if skill.name in local_skills:
         return ConflictInfo(
             skill_name=skill.name, local_path=f"./{skill.name}", external_source="local"
         )
-    if skill.name in synced_skills:
+    conflict_sources = synced_skills.get(skill.name, set()) - {skill.source.name}
+    if conflict_sources:
         return ConflictInfo(
             skill_name=skill.name,
             local_path=f"./external/*/{skill.name}",
-            external_source="synced",
+            external_source=f"synced ({', '.join(sorted(conflict_sources))})",
         )
     return None
 
@@ -449,6 +522,8 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
             - errors: Number of errors encountered
     """
     sources = load_config(config_path)
+    existing_external_skills = load_existing_external_skills(sources)
+    local_skills = get_local_skills()
 
     all_synced_skills = []  # List of (Skill, commit_sha) tuples
     all_skipped = []
@@ -468,11 +543,12 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
 
             skills = find_skills(repo_path, source)
             print(f"  Found {len(skills)} skills")
+            current_skill_names = {skill.name for skill in skills}
+            prune_removed_source_skills(existing_external_skills, source, current_skill_names)
 
-            local_skills = get_local_skills()
-            synced_skills = get_synced_skills()
+            synced_skills = build_synced_skill_index(existing_external_skills)
             print(f"  Local skills: {len(local_skills)}")
-            print(f"  Already synced: {len(synced_skills)}")
+            print(f"  Already synced: {len(existing_external_skills)}")
 
             for skill in skills:
                 conflict = detect_conflicts(skill, local_skills, synced_skills)
@@ -497,6 +573,10 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
                             has_skill_md=True,
                         )
                         all_synced_skills.append((synced_skill, commit_sha))
+                        existing_external_skills[(skill.source.name, skill.name)] = (
+                            synced_skill,
+                            commit_sha,
+                        )
                     else:
                         print(f"  ❌ Validation failed for {skill.name}")
                         all_errors.append((skill.name, "Validation failed"))
@@ -512,11 +592,15 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
             all_errors.append((source.name, str(e)))
 
     # Update marketplace.json and README.md with synced skills
-    if all_synced_skills:
-        print("\nUpdating marketplace.json...")
-        update_marketplace(all_synced_skills)
-        print("\nUpdating README.md...")
-        update_readme(all_synced_skills)
+    merged_synced_skills = sorted(
+        existing_external_skills.values(),
+        key=lambda item: (item[0].source.name, item[0].name),
+    )
+
+    print("\nUpdating marketplace.json...")
+    update_marketplace(merged_synced_skills)
+    print("\nUpdating README.md...")
+    update_readme(merged_synced_skills)
 
     # Return summary statistics
     results = {
@@ -659,11 +743,11 @@ def update_marketplace(
     for skill, commit_sha in synced_skills:
         skills_by_source[skill.source.name].append((skill, commit_sha))
 
-    # Remove existing external entries for these sources
-    external_group_names = {
-        f"external-{name}-skills" for name in skills_by_source.keys()
-    }
-    plugins = [p for p in plugins if p.get("name") not in external_group_names]
+    plugins = [
+        p
+        for p in plugins
+        if not (isinstance(p, dict) and p.get("external") is True)
+    ]
 
     # Create grouped entries for each source
     for source_name, skills_list in skills_by_source.items():

--- a/tests/test_sync_external_skills.py
+++ b/tests/test_sync_external_skills.py
@@ -1,10 +1,143 @@
 """Tests for sync_external_skills module."""
 
-import pytest
+import os
+from pathlib import Path
+
+from scripts.sync_external_skills import (
+    build_synced_skill_index,
+    detect_conflicts,
+    load_existing_external_skills,
+    prune_removed_source_skills,
+)
+from scripts.sync_types import ExternalSource, Skill
 
 
-# Placeholder - actual tests will be added with each feature
-class TestPlaceholder:
-    def test_placeholder(self):
-        """Placeholder test."""
-        pass
+def write_skill(skill_dir: Path, name: str, commit_sha: str = "abc123") -> None:
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                f"name: {name}",
+                "description: Test skill description long enough",
+                f"synced-commit: {commit_sha}",
+                "---",
+                "",
+                "# Test Skill",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_load_existing_external_skills_reads_current_disk_state(tmp_path: Path) -> None:
+    external_root = tmp_path / "external"
+    write_skill(external_root / "source-a" / "skill-one", "external-source-a-skill-one")
+    write_skill(
+        external_root / "source-b" / "skill-two",
+        "external-source-b-skill-two",
+        commit_sha="def456",
+    )
+    write_skill(
+        external_root / "ignored-source" / "skill-three",
+        "external-ignored-source-skill-three",
+        commit_sha="zzz999",
+    )
+
+    sources = [
+        ExternalSource(name="source-a", url="https://example.com/a.git"),
+        ExternalSource(name="source-b", url="https://example.com/b.git"),
+    ]
+
+    existing = load_existing_external_skills(sources, external_root=external_root)
+
+    assert set(existing.keys()) == {("source-a", "skill-one"), ("source-b", "skill-two")}
+    assert existing[("source-a", "skill-one")][1] == "abc123"
+    assert existing[("source-b", "skill-two")][1] == "def456"
+
+
+def test_detect_conflicts_allows_resync_from_same_source() -> None:
+    source = ExternalSource(name="source-a", url="https://example.com/a.git")
+    skill = Skill(name="skill-one", path=Path("/tmp/skill-one"), source=source, has_skill_md=True)
+
+    synced_index = build_synced_skill_index(
+        {
+            ("source-a", "skill-one"): (skill, "abc123"),
+        }
+    )
+
+    assert detect_conflicts(skill, local_skills=set(), synced_skills=synced_index) is None
+
+
+def test_detect_conflicts_blocks_other_synced_sources() -> None:
+    source = ExternalSource(name="source-a", url="https://example.com/a.git")
+    other_source = ExternalSource(name="source-b", url="https://example.com/b.git")
+    skill = Skill(name="skill-one", path=Path("/tmp/skill-one"), source=source, has_skill_md=True)
+    other_skill = Skill(
+        name="skill-one",
+        path=Path("/tmp/other-skill-one"),
+        source=other_source,
+        has_skill_md=True,
+    )
+
+    synced_index = build_synced_skill_index(
+        {
+            ("source-b", "skill-one"): (other_skill, "def456"),
+        }
+    )
+
+    conflict = detect_conflicts(skill, local_skills=set(), synced_skills=synced_index)
+
+    assert conflict is not None
+    assert conflict.skill_name == "skill-one"
+    assert conflict.external_source == "synced (source-b)"
+
+
+def test_load_existing_external_skills_keeps_recorded_source_url(tmp_path: Path) -> None:
+    external_root = tmp_path / "external"
+    skill_dir = external_root / "source-a" / "skill-one"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: external-source-a-skill-one",
+                "description: Test skill description long enough",
+                "synced-commit: abc123",
+                "synced-from: https://old.example.com/a.git",
+                "---",
+                "",
+                "# Test Skill",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    existing = load_existing_external_skills(
+        [ExternalSource(name="source-a", url="https://new.example.com/a.git")],
+        external_root=external_root,
+    )
+
+    assert existing[("source-a", "skill-one")][0].source.url == "https://old.example.com/a.git"
+
+
+def test_prune_removed_source_skills_removes_stale_same_source_entries(tmp_path: Path) -> None:
+    source = ExternalSource(name="source-a", url="https://example.com/a.git")
+    kept_dir = tmp_path / "external" / "source-a" / "kept-skill"
+    stale_dir = tmp_path / "external" / "source-a" / "stale-skill"
+    write_skill(kept_dir, "external-source-a-kept-skill", commit_sha="abc123")
+    write_skill(stale_dir, "external-source-a-stale-skill", commit_sha="def456")
+
+    existing = load_existing_external_skills([source], external_root=tmp_path / "external")
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        prune_removed_source_skills(existing, source, {"kept-skill"})
+    finally:
+        os.chdir(original_cwd)
+
+    assert ("source-a", "kept-skill") in existing
+    assert ("source-a", "stale-skill") not in existing
+    assert kept_dir.exists()
+    assert not stale_dir.exists()


### PR DESCRIPTION
## 变更描述

修复 external skills 重复同步时的状态计算问题，避免上游仓库更新后再次运行同步脚本时，把之前已同步的 skill 从 README / marketplace 或 external 目录状态中错误移除。

### 变更类型
- [ ] 新增 Skill
- [ ] 更新现有 Skill
- [x] 修复问题
- [ ] 其他（请说明）

### 涉及的 Skill
Skill 名称：external sync workflow / scripts/sync_external_skills.py

### 变更内容摘要
- 同步时先读取 `external/{source}/{skill}` 的现有状态，README 和 marketplace 基于合并后的 external 实际状态重建，而不是只依赖本次成功同步的 skill 列表。
- 同源 skill 允许重复同步更新，同时会清理同源上游已删除的 skill，避免“重复同步误删”和“历史残留不清理”两种问题。

---

## 检查清单

### SKILL.md 格式检查
- [x] `name` 字段与目录名完全匹配
- [x] `description` 字段不少于 20 个字符
- [x] frontmatter 格式正确（以 `---` 开头和结尾）
- [x] 包含 `description` 字段用于 Agent 匹配
- [x] 正文中无 `[TODO]` 或 `[TODO:xxx]` 占位符

### 内容完整性检查
- [x] 内部链接可正常访问（如 `references/xxx.md`）
- [x] 代码块已标注语言（如 ```bash、```python）
- [x] 表格格式正确（如有）

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`
- [x] 已更新 `README.md` 中的 Skill 列表（如适用）

---

## 测试说明

### 本地验证
```bash
python3 -m pytest tests/test_sync_external_skills.py
python3 scripts/validate_skills.py
python3 -m py_compile scripts/sync_external_skills.py tests/test_sync_external_skills.py
```

#### 1. 验证脚本测试结果
```
$ python3 -m pytest tests/test_sync_external_skills.py
============================= test session starts ==============================
collected 5 items

tests/test_sync_external_skills.py .....                                 [100%]

============================== 5 passed in 0.02s ===============================

$ python3 scripts/validate_skills.py
Summary: 27 files checked
  Errors: 0
  Warnings: 1

✅ Validation PASSED!
```

#### 2. Skill 功能测试（如适用）
- [ ] 已在 AI Agent 中测试 Skill 触发
- [ ] 已验证 Skill 内容正确加载

未涉及单个 Skill 内容触发，本次主要验证 sync 脚本行为与回归测试。

---

## 其他说明

### 关联 Issue
Fixes #

### 截图（如适用）
本次为脚本逻辑修复，无界面截图。