### PR TITLE
fix(diffusers-ascend-weight): handle None components and add fake weight generation

### DIFF
--- a/diffusers-ascend/diffusers-ascend-weight-prep/scripts/generate_fake_weights.py
+++ b/diffusers-ascend/diffusers-ascend-weight-prep/scripts/generate_fake_weights.py
@@ -81,6 +81,12 @@ def generate_from_local_metadata(
             continue
 
         library_name, class_name = comp_info
+
+        # Handle None values (skip components with no library/class)
+        if library_name is None or class_name is None:
+            print(f"\n--- {comp_name}: None (skipped) ---")
+            continue
+
         comp_metadata_dir = os.path.join(metadata_dir, comp_name)
         comp_output_dir = os.path.join(output_dir, comp_name)
 


### PR DESCRIPTION
## Summary
- Fix handling of None library/class in model components for diffusers-ascend-weight-prep
- Add generate_fake_weights.py script for testing without real weights

## Test plan
- [ ] Verify weight preparation script handles None components gracefully
- [ ] Test fake weight generation with various model configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)