### PR TITLE
feat(mindspeed-mm): add MindSpeed-MM skills collection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -214,6 +214,19 @@
         "description": "指导并自动化完成昇腾 NPU 上 MindSpeed-LLM 训练的 Profiling 数据采集。支持配置并运行带 Profiling 的模型训练，包括 CPU 采集、内存采集、不同采集级别（level0/level1/level2）和自定义 step 范围。生成的 Profiling 数据可用 MindStudio Insight 进行性能分析。当用户需要在模型训练中采集 Profiling 数据、进行训练性能分析、或执行 性能数据采集/Profiling采集 时触发。触发关键词：profiling、性能分析、性能数据采集、Profiling采集、训练框架profiling、MindSpeed-LLM profiling。",
         "source": "./mindspeed-llm-train-profiler",
         "category": "development"
+    },
+    {
+      "name": "mindspeed-mm-skills",
+      "description": "MindSpeed-MM 多模态大模型训练技能集，用于华为昇腾 NPU。覆盖环境搭建、权重转换（mm-convert）、多模态理解模型（VLM：Qwen2.5VL/InternVL/GLM4V）训练、多模态生成模型（Wan/HunyuanVideo/CogVideoX/FLUX）训练、端到端流水线。Use when deploying MindSpeed-MM multimodal training on Ascend NPU.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./mindspeed-mm/mindspeed-mm-pipeline",
+        "./mindspeed-mm/mindspeed-mm-env-setup",
+        "./mindspeed-mm/mindspeed-mm-weight-prep",
+        "./mindspeed-mm/mindspeed-mm-vlm",
+        "./mindspeed-mm/mindspeed-mm-generative"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ cp -r awesome-ascend-skills/npu-smi your-project/.agents/skills/
 | [profiling-analysis](profiling-analysis/profiling-main/SKILL.md) | 分析 | Profiling 性能分析技能集：分析 step_trace_time.csv 识别下发、通信、计算瓶颈 |
 | [mindspeed-llm-train-profiler](mindspeed-llm-train-profiler/SKILL.md) | 分析 | 自动化完成昇腾 NPU 上 MindSpeed-LLM 训练的 Profiling 数据采集 |
 | [ai-for-science](ai-for-science/ai4s-main/SKILL.md) | 开发 | AI for Science 总入口：负责 Profiling 采集、模型迁移、TensorFlow/Keras 路线选择，并分流到对应子 skill。 |
+| [mindspeed-mm-pipeline](mindspeed-mm/mindspeed-mm-pipeline/SKILL.md) | 开发 | MindSpeed-MM 模型路由：根据模型类型（VLM/生成/全模态/音频）引导至对应 Skill |
+| [mindspeed-mm-env-setup](mindspeed-mm/mindspeed-mm-env-setup/SKILL.md) | 开发 | MindSpeed-MM 环境搭建：CANN + torch_npu + MindSpeed + Megatron-LM + MindSpeed-MM 安装 |
+| [mindspeed-mm-weight-prep](mindspeed-mm/mindspeed-mm-weight-prep/SKILL.md) | 开发 | MindSpeed-MM 权重转换：mm-convert CLI 工具，HF↔MM/DCP 格式转换，PP 重切分 |
+| [mindspeed-mm-vlm](mindspeed-mm/mindspeed-mm-vlm/SKILL.md) | 开发 | MindSpeed-MM VLM 训练：Qwen2.5VL/InternVL/GLM4V 等理解模型，支持 Megatron/FSDP2/Custom 三种后端 |
+| [mindspeed-mm-generative](mindspeed-mm/mindspeed-mm-generative/SKILL.md) | 开发 | MindSpeed-MM 生成模型训练：Wan/HunyuanVideo/CogVideoX/FLUX 等视频/图像生成，含特征提取 |
 
 ## 外部 Skills (External Skills)
 

--- a/mindspeed-mm/mindspeed-mm-env-setup/SKILL.md
+++ b/mindspeed-mm/mindspeed-mm-env-setup/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: mindspeed-mm-env-setup
+description: MindSpeed-MM multimodal model suite environment setup guide for Huawei Ascend NPU. Covers CANN activation, PyTorch + torch_npu installation, MindSpeed acceleration library, Megatron-LM core module integration, and MindSpeed-MM installation. Use when setting up MindSpeed-MM multimodal training environment on Ascend NPU.
+keywords:
+    - mindspeed
+    - mindspeed-mm
+    - multimodal
+    - environment
+    - installation
+    - cann
+    - torch_npu
+    - megatron
+    - ascend npu
+---
+
+# MindSpeed-MM Ascend NPU Base Environment Setup
+
+This skill guides users through setting up the **base** environment for MindSpeed-MM multimodal training on Huawei Ascend NPU.
+
+> **Important**: This guide only covers the base environment. Different multimodal models (qwen3vl, wan2.2, hunyuanvideo, etc.) have vastly different dependency version requirements that may conflict with each other. Model-specific dependencies must be installed on top of the base environment. After completing this guide, refer to the corresponding model's SKILL for additional configuration.
+
+## Component Relationship
+
+```
+Megatron-LM (NVIDIA)     <- Distributed training core (TP/PP), uses core_v0.12.1 branch
+    |
+MindSpeed (Huawei)       <- Ascend adaptation layer, monkey-patches Megatron kernels
+    |
+MindSpeed-MM (Huawei)    <- Multimodal application layer: VLM/generation/omni-modal training
+```
+
+MindSpeed-MM shares the underlying dependency stack (CANN, torch_npu, MindSpeed, Megatron-LM) with MindSpeed-LLM, but targets multimodal scenarios at the application level (vision-language models, video generation, speech synthesis, etc.).
+
+## Quick Start -- 6 Steps to Complete the Base Environment
+
+```bash
+# 1. Activate CANN environment (CANN 8.5.0+ path; for older versions use /usr/local/Ascend/ascend-toolkit/set_env.sh)
+source /usr/local/Ascend/cann/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+
+# 2. Install PyTorch + torch_npu — USE PRE-BUILT WHEELS from https://gitcode.com/Ascend/pytorch/releases
+# Do NOT use `pip install torch==2.7.1` — aarch64 wheels on PyPI are unreliable
+# For Python 3.10 + aarch64:
+pip install torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl
+pip install torch_npu-2.7.1rc1-cp310-cp310-manylinux_2_28_aarch64.whl
+pip install numpy pyyaml scipy attrs decorator psutil
+
+# 3. Clone and install MindSpeed (pinned to a specific commit)
+git clone https://gitcode.com/ascend/MindSpeed.git
+cd MindSpeed
+git checkout 93c45456c7044bacddebc5072316c01006c938f9
+pip install -r requirements.txt && pip install -e .
+cd ..
+
+# 4. Clone Megatron-LM and copy the core module into MindSpeed-MM
+git clone https://github.com/NVIDIA/Megatron-LM.git
+cd Megatron-LM && git checkout core_v0.12.1 && cd ..
+git clone https://gitcode.com/Ascend/MindSpeed-MM.git
+cp -r Megatron-LM/megatron MindSpeed-MM/
+
+# 5. Install MindSpeed-MM
+cd MindSpeed-MM
+pip install -e .
+
+# 6. Verify the environment
+python -c "
+import torch
+import torch_npu
+print(f'NPUs available: {torch_npu.npu.device_count()}')
+print(f'NPU ready: {torch.npu.is_available()}')
+"
+```
+
+## One-Click Install Script (Qwen3/Qwen3.5 ONLY)
+
+MindSpeed-MM provides `scripts/install.sh`, but **official docs state it only fully supports Qwen3 and Qwen3.5 models**. For all other models (Qwen2.5VL, Wan2.1/2.2, InternVL, HunyuanVideo, etc.), use the manual install above.
+
+```bash
+# ONLY for Qwen3 / Qwen3.5:
+git clone https://gitcode.com/Ascend/MindSpeed-MM.git
+cd MindSpeed-MM
+bash scripts/install.sh --msid eb10b92 && bash examples/qwen3_5/install_extensions.sh
+```
+
+> **Warning**: On ARM (aarch64), `install.sh` uses `pip install torch torchvision torchaudio` from PyPI, which frequently fails because aarch64 wheels are not consistently available. For ARM, prefer the manual install method with pre-built wheels from [Ascend PyTorch Releases](https://gitcode.com/Ascend/pytorch/releases).
+
+### install.sh Parameter Reference
+
+| Flag | Long Flag | Description |
+|------|-----------|-------------|
+| `-t` | `--torchversion` | Specify PyTorch version string (any user-provided version, default `2.7.1`) |
+| `-m` | `--msid` | **Required**. MindSpeed commit ID specifying the MindSpeed version to install |
+| `-y` | `--yes` | Auto-confirm installation, skipping interactive prompts |
+| `-n` | `--no` | Auto-skip all reinstallation prompts |
+| `-mt` | `--megatron` | Install Megatron-LM (boolean toggle, default: SKIP; only installs when explicitly set) |
+| `-ic` | `--install-cann` | Also install the CANN environment (not installed by default; assumes CANN is already present) |
+
+**Example: Specify PyTorch 2.6.0 and auto-confirm**
+
+```bash
+bash scripts/install.sh --msid eb10b92 -t 2.6.0 -y
+```
+
+## Version Compatibility Matrix
+
+| MindSpeed-MM | MindSpeed | Megatron-LM | PyTorch | torch_npu | CANN |
+|---|---|---|---|---|---|
+| master | master | core_v0.12.1 | 2.6.0, 2.7.1 | in-development | in-development |
+
+> The above reflects the current master branch. Both MindSpeed-MM and MindSpeed are under rapid iteration; it is recommended to use a pinned commit rather than master HEAD.
+> Check CANN version: `cat /usr/local/Ascend/cann/latest/aarch64-linux/ascend_toolkit_install.info` (CANN 8.5.0+) or `cat /usr/local/Ascend/ascend-toolkit/latest/aarch64-linux/ascend_toolkit_install.info` (older versions).
+
+## Docker Container Creation
+
+```bash
+docker run -it --name mindspeed-mm \
+    --privileged \
+    --network host \
+    --ipc=host \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64:/usr/local/Ascend/driver/lib64 \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /home/workspace:/home/workspace \
+    <cann-image> bash
+```
+
+> **Warning**: If `--ipc=host` is not available, set `--shm-size=16g`. Without proper shared memory configuration, DataLoader workers will crash with `Bus error`. As a workaround, set `--num-workers 0` in all training and feature extraction scripts.
+
+> Note: The CANN container image does not include ML dependencies; after entering the container you must manually install PyTorch, torch_npu, etc.
+> **It is strongly recommended to create a separate container for each multimodal model** to avoid dependency version conflicts.
+
+## Directory Structure
+
+After installation, the workspace structure should look like this:
+
+```
+workspace/
+├── MindSpeed/                    # Acceleration library
+├── MindSpeed-MM/                 # Main project
+│   ├── megatron/                 # Core module copied from Megatron-LM
+│   ├── mindspeed_mm/             # Multimodal core code
+│   ├── examples/                 # Example scripts and configs for each model
+│   ├── scripts/
+│   │   └── install.sh            # One-click install script
+│   └── pyproject.toml            # Base dependency definitions
+├── Megatron-LM/                  # NVIDIA original repo (used only to copy megatron/)
+├── model_from_hf/                # Model weights
+└── dataset/                      # Training datasets
+```
+
+## Base Dependency Versions (pyproject.toml)
+
+The base installation (`pip install -e .`) installs the following core dependencies:
+
+| Package | Base Version |
+|---|---|
+| torch | 2.7.1 |
+| transformers | 4.57.0 |
+| diffusers | 0.30.3 |
+| peft | 0.7.1 |
+| accelerate | 0.32.1 |
+
+## Model-Specific Dependency Conflict Warning
+
+> **Critical Warning**: The multimodal models supported by MindSpeed-MM have vastly different dependency version requirements that may conflict with the base environment.
+
+**Known conflict examples**:
+- **qwen3vl**: Requires installing transformers from git source (specific commit c0dbe09), incompatible with base version 4.57.0
+- **wan2.2**: Requires diffusers==0.35.1, peft==0.17.1, overriding base versions
+- **hunyuanvideo_1.5**: Requires transformers==4.57.1, diffusers==0.35.0, also incompatible with wan2.2
+- **deepseekocr**: Requires transformers==4.46.3 (**downgrade!**), conflicts with all other models
+
+**Docker shared memory**: When running in Docker containers, ensure adequate shared memory is configured (`--ipc=host` or `--shm-size=16g`). Default Docker shm (64MB) will cause `Bus error` in DataLoader workers. If you cannot change the container settings, set `--num-workers 0` in all training scripts.
+
+**Isolation recommendations**:
+- Create a separate Docker container or conda/venv environment for each model
+- Complete the base environment setup first, then install model-specific dependencies in an isolated environment
+- See [references/version-matrix.md](references/version-matrix.md) for the full conflict matrix
+
+## Environment Verification Checklist
+
+| Check Item | Command | Expected Result |
+|------------|---------|-----------------|
+| CANN environment | `npu-smi info` | Displays NPU device information |
+| PyTorch | `python -c "import torch; print(torch.__version__)"` | `2.7.1` |
+| torch_npu | `python -c "import torch_npu; print(torch_npu.__version__)"` | `2.7.1rc1` |
+| NPU available | `python -c "import torch; import torch_npu; print(torch.npu.is_available())"` | `True` |
+| NPU count | `python -c "import torch_npu; print(torch_npu.npu.device_count())"` | >= 1 (matching hardware) |
+| MindSpeed | `pip show mindspeed` | Displays package information |
+| megatron module | `ls MindSpeed-MM/megatron/` | Directory exists and is non-empty |
+| MindSpeed-MM | `pip show mindspeed-mm` | Displays package information |
+| transformers | `python -c "import transformers; print(transformers.__version__)"` | `4.57.0` (base version) |
+| diffusers | `python -c "import diffusers; print(diffusers.__version__)"` | `0.30.3` (base version) |
+
+## Smoke Test
+
+Run this quick preflight check before starting any training job:
+
+```bash
+python3 -c "
+import torch, torch_npu
+assert torch.npu.is_available(), 'NPU not available'
+print(f'NPU count: {torch_npu.npu.device_count()}')
+import transformers, diffusers, mindspeed
+print(f'transformers={transformers.__version__}, diffusers={diffusers.__version__}')
+print('Smoke test passed')
+"
+```
+
+If any import fails or the assertion triggers, revisit the corresponding installation step above.
+
+## FAQ
+
+**Q: `ModuleNotFoundError: No module named 'yaml'` when importing torch_npu**
+
+The CANN Docker image is missing basic Python packages:
+
+```bash
+pip install numpy pyyaml scipy attrs decorator psutil
+```
+
+**Q: pip install or git clone fails due to network issues**
+
+Use a proxy:
+
+```bash
+export http_proxy=http://127.0.0.1:7890
+export https_proxy=http://127.0.0.1:7890
+pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cpu
+```
+
+**Q: Cannot find the Megatron-LM checkout branch**
+
+Make sure you are using the correct branch name (note the `core_v` prefix):
+
+```bash
+cd Megatron-LM
+git branch -a | grep core
+git checkout core_v0.12.1
+```
+
+**Q: MindSpeed commit does not exist**
+
+Make sure you are using the full commit hash:
+
+```bash
+cd MindSpeed
+git log --oneline | head -20
+git checkout 93c45456c7044bacddebc5072316c01006c938f9
+```
+
+**Q: `pip install -e .` fails when installing MindSpeed-MM**
+
+Check that the megatron module has been copied into the MindSpeed-MM directory and that pyproject.toml exists:
+
+```bash
+ls MindSpeed-MM/megatron/
+ls MindSpeed-MM/pyproject.toml
+```
+
+**Q: Training fails with `Communication_Error_Bind_IP_Port`**
+
+A stale process from a previous run is holding the port. Kill it and use a different port:
+
+```bash
+# Find and kill stale processes
+ps aux | grep torchrun | grep -v grep | awk '{print $2}' | xargs kill -9
+# Or use a different port in the training script
+export MASTER_PORT=6100
+```
+
+**Q: Base environment is broken after installing model-specific dependencies**
+
+This is expected behavior. Different models require conflicting versions of transformers/diffusers/peft. Solutions:
+
+```bash
+# Option 1: Separate Docker containers (recommended)
+docker run -it --name mindspeed-mm-qwen3vl ...
+
+# Option 2: conda virtual environments
+conda create -n mm-qwen3vl python=3.10
+conda activate mm-qwen3vl
+# Re-run base installation + model-specific dependencies
+```
+
+## Next Steps
+
+The base environment setup is complete. Next, install additional dependencies for the specific model you need. Refer to the corresponding model's SKILL.
+
+## References
+
+- [Version Conflict Matrix](references/version-matrix.md) - Dependency version conflict details for each model
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)
+- [MindSpeed Repository](https://gitcode.com/ascend/MindSpeed)
+- [Megatron-LM](https://github.com/NVIDIA/Megatron-LM)
+- [Ascend Documentation](https://www.hiascend.com/document)

--- a/mindspeed-mm/mindspeed-mm-env-setup/references/version-matrix.md
+++ b/mindspeed-mm/mindspeed-mm-env-setup/references/version-matrix.md
@@ -1,0 +1,94 @@
+# MindSpeed-MM Model Dependency Version Conflict Matrix
+
+This document lists the version requirements for key dependency packages across MindSpeed-MM multimodal models, along with their conflicts with the base environment (pyproject.toml).
+
+## Version Conflict Matrix
+
+| Model | transformers | diffusers | peft | Additional Dependencies |
+|---|---|---|---|---|
+| **Base (pyproject.toml)** | 4.57.0 | 0.30.3 | 0.7.1 | -- |
+| **qwen3vl** | from git (c0dbe09) | -- | -- | triton-ascend, accelerate==1.2.0 |
+| **qwen3_5** | from source | -- | -- | triton-ascend, accelerate==1.2.0 |
+| **wan2.2** | -- | 0.35.1 | 0.17.1 | -- |
+| **hunyuanvideo_1.5** | 4.57.1 | 0.35.0 | 0.17.0 | omegaconf, modelscope, angelslim |
+| **deepseekocr** | 4.46.3 (downgrade!) | -- | -- | PyMuPDF, img2pdf |
+| **cosyvoice3** | -- | -- | -- | torchaudio, openai-whisper, pyworld, librosa |
+| **qwen3tts** | 4.57.3 | -- | -- | torchaudio, librosa, sox, gradio |
+
+> `--` indicates that the model does not override the base version and uses the default from pyproject.toml.
+
+## Conflict Analysis
+
+### transformers Version Conflicts
+
+transformers has the most severe conflicts:
+
+- **Base version**: 4.57.0
+- **qwen3vl / qwen3_5**: Requires installation from git source at a specific commit (c0dbe09), incompatible with any PyPI version
+- **hunyuanvideo_1.5**: Requires 4.57.1 (minor version upgrade, relatively low risk)
+- **qwen3tts**: Requires 4.57.3 (minor version upgrade, relatively low risk)
+- **deepseekocr**: Requires 4.46.3 (**major downgrade**, conflicts with all other models)
+
+### diffusers Version Conflicts
+
+- **Base version**: 0.30.3
+- **wan2.2**: Requires 0.35.1 (major version upgrade)
+- **hunyuanvideo_1.5**: Requires 0.35.0 (major version upgrade, but also incompatible with wan2.2's 0.35.1)
+
+### peft Version Conflicts
+
+- **Base version**: 0.7.1
+- **wan2.2**: Requires 0.17.1 (major version upgrade)
+- **hunyuanvideo_1.5**: Requires 0.17.0 (major version upgrade, incompatible with wan2.2's 0.17.1)
+
+## Isolation Recommendations
+
+Due to severe version conflicts, **it is strongly recommended to use an isolated environment for each model**:
+
+### Option 1: Separate Docker Containers (Recommended)
+
+Create a separate Docker container for each model, installing dependencies independently based on the CANN base image:
+
+```bash
+# Example: Create a separate container for qwen3vl
+docker run -it --name mindspeed-mm-qwen3vl \
+    --device /dev/davinci0 \
+    ... \
+    swr.cn-south-1.myhuaweicloud.com/ascendhub/cann:8.5.0-910b-ubuntu22.04-py3.10 \
+    bash
+
+# After completing the base installation inside the container, install qwen3vl-specific dependencies
+```
+
+### Option 2: conda Virtual Environments
+
+```bash
+# Create a separate environment for each model
+conda create -n mm-qwen3vl python=3.10
+conda create -n mm-wan22 python=3.10
+conda create -n mm-hunyuanvideo python=3.10
+
+# Complete base installation + model-specific dependencies in each environment
+conda activate mm-qwen3vl
+# ... installation steps ...
+```
+
+### Option 3: Python venv
+
+```bash
+python -m venv /opt/envs/mm-qwen3vl
+source /opt/envs/mm-qwen3vl/bin/activate
+# ... installation steps ...
+```
+
+## Model Grouping Recommendations
+
+The following models can share the same environment (no dependency conflicts):
+
+| Environment Group | Shareable Models | Notes |
+|---|---|---|
+| Base group | cosyvoice3 | Does not override base dependency versions; only adds extra dependencies |
+| qwen group | qwen3vl, qwen3_5 | Both require git-source transformers + triton-ascend |
+| Video generation group | -- | wan2.2 and hunyuanvideo_1.5 have incompatible diffusers/peft versions and cannot share an environment |
+
+> Note: Even for models marked as shareable, it is still recommended to use separate environments in practice to avoid potential hidden conflicts.

--- a/mindspeed-mm/mindspeed-mm-generative/SKILL.md
+++ b/mindspeed-mm/mindspeed-mm-generative/SKILL.md
@@ -1,0 +1,500 @@
+---
+name: mindspeed-mm-generative
+description: Universal MindSpeed-MM generative model training guide for Huawei Ascend NPU. Covers all backend patterns (Megatron, Megatron+FSDP2, FSDP2-native, Accelerate+DeepSpeed), feature extraction, weight conversion, and training for ALL supported generative models. Supports Wan2.1/2.2, HunyuanVideo/1.5, CogVideoX, OpenSoraPlan, VACE, LTX2, FLUX, SD3, SDXL, Sana, HiDream, StepVideo, Lumina and more. Use when training multimodal generative models on Ascend NPU.
+keywords:
+    - mindspeed-mm
+    - generative
+    - video generation
+    - image generation
+    - wan
+    - t2v
+    - t2i
+    - i2v
+    - feature extraction
+    - sora
+    - diffusion
+    - flux
+    - hunyuanvideo
+    - cogvideox
+    - accelerate
+    - fsdp2
+---
+
+# MindSpeed-MM Generative Model Training
+
+This Skill guides users through the end-to-end training pipeline for multimodal generative models (text-to-video, text-to-image) on Huawei Ascend NPU.
+
+## Prerequisites
+
+> **Critical**: Do NOT use `bash scripts/install.sh` for generative models. Official MindSpeed-MM docs state `install.sh` only fully supports Qwen3/Qwen3.5. For Wan2.1 and other generative models, follow the **manual install** flow below (matches `examples/wan2.1/README.md`).
+
+### Step P1: Clone repositories
+
+```bash
+git clone https://gitcode.com/Ascend/MindSpeed-MM.git /root/workspace/MindSpeed-MM
+git clone https://github.com/NVIDIA/Megatron-LM.git /root/workspace/Megatron-LM
+cd /root/workspace/Megatron-LM && git checkout core_v0.12.1
+cp -r megatron /root/workspace/MindSpeed-MM/
+cd /root/workspace/MindSpeed-MM
+```
+
+### Step P2: Install PyTorch + torch_npu
+
+**Always use pre-built wheels** from [Ascend PyTorch Releases](https://gitcode.com/Ascend/pytorch/releases). Do **not** use `pip install torch==2.7.1` — aarch64 wheels on PyPI are unreliable.
+
+```bash
+# Download matching wheels from https://gitcode.com/Ascend/pytorch/releases
+# Replace cp310 with cp311 if using Python 3.11
+pip install torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl
+pip install torch_npu-2.7.1rc1-cp310-cp310-manylinux_2_28_aarch64.whl
+# For x86_64: same naming pattern with _x86_64 suffix
+
+# Required by torch_npu and other components:
+pip install numpy pyyaml scipy attrs decorator psutil
+```
+
+### Step P3: Install MindSpeed
+
+```bash
+git clone https://gitcode.com/Ascend/MindSpeed.git /root/workspace/MindSpeed
+cd /root/workspace/MindSpeed
+git checkout 93c45456c7044bacddebc5072316c01006c938f9
+pip install -r requirements.txt
+pip install -e .
+cd /root/workspace/MindSpeed-MM
+```
+
+### Step P4: Install MindSpeed-MM base dependencies
+
+```bash
+# Installs base stack from pyproject.toml: transformers==4.57.0, diffusers==0.30.3, peft==0.7.1, etc.
+pip install -e .
+```
+
+### Step P5: Activate CANN environment
+
+```bash
+source /usr/local/Ascend/cann/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+### Step P6: Smoke test
+
+```bash
+python3 -c "
+import torch, torch_npu
+assert torch.npu.is_available(), 'NPU not available'
+print(f'NPU count: {torch_npu.npu.device_count()}')
+import transformers, diffusers, mindspeed
+print(f'transformers={transformers.__version__}, diffusers={diffusers.__version__}')
+"
+```
+
+**Then proceed to Step 0** below for model-specific dependencies (diffusers upgrade, decord, etc.) — Prerequisites alone is NOT enough for any generative model.
+
+For detailed troubleshooting and alternative install paths, see [mindspeed-mm-env-setup](../mindspeed-mm-env-setup/SKILL.md).
+
+## Supported Models
+
+| Model | Sub-tasks | Backend | Status |
+|---|---|---|---|
+| Wan2.1 | t2v, i2v, v2v, flf2v | Megatron | Released |
+| Wan2.2 | t2v, i2v | Megatron+FSDP2 | Released |
+| HunyuanVideo | t2v, i2v | Megatron | Prototype |
+| HunyuanVideo 1.5 | t2v, i2v | Megatron+FSDP2 | Prototype |
+| CogVideoX | t2v | Megatron | Released |
+| OpenSoraPlan 1.3/1.5 | t2v | Megatron | Released |
+| OpenSora 2.0 | t2v | Megatron | Released |
+| StepVideo | t2v | Megatron | Prototype |
+| VACE | t2v | Megatron+FSDP2 | Prototype |
+| LTX2 | t2v | FSDP2-native | Prototype |
+| FLUX | t2i | Accelerate+DeepSpeed | Prototype |
+| SD3 | t2i | Accelerate+DeepSpeed | Prototype |
+| SDXL | t2i | Accelerate+DeepSpeed | Prototype |
+| Sana | t2i | Accelerate+DeepSpeed | Prototype |
+| HiDream | t2i | Accelerate+DeepSpeed | Prototype |
+| Lumina | t2v | Megatron | Prototype |
+
+**Sub-task descriptions**:
+- **t2v** (text-to-video): Generate video from text, the most fundamental generation task
+- **i2v** (image-to-video): Generate video from image + text, requires a reference image and different model weights
+- **v2v** (video-to-video): Video style transfer
+- **flf2v** (first-last-frame-to-video): Generate intermediate video from the first and last frames
+
+## How to Train Any Generative Model
+
+For ANY generative model, use the [Model Registry](../mindspeed-mm-pipeline/references/model-registry.md) to look up the exact backend, entry script, converter, and feature extraction script. Then:
+
+1. Check `examples/<model_name>/README.md` for model-specific instructions
+2. Read the shell script to identify: entry script, config files, backend pattern
+3. Check if the model needs feature extraction (not all do — see registry)
+4. Check if the model needs weight conversion (diffusers models use HF weights directly)
+5. Modify config files with your data/weight paths
+6. Launch the shell script
+
+### Backend Patterns
+
+MindSpeed-MM uses four different training backends depending on the model:
+
+| Backend | Entry Script | Models | Notes |
+|---|---|---|---|
+| Megatron | `pretrain_sora.py` | wan2.1, hunyuanvideo, cogvideox, opensoraplan1.3/1.5, opensora2.0, stepvideo | Standard Megatron distributed training |
+| Megatron+FSDP2 | `pretrain_sora.py` + `--use-torch-fsdp2` | wan2.2, hunyuanvideo_1.5, vace | Requires `CUDA_DEVICE_MAX_CONNECTIONS=2` |
+| FSDP2-native | `mindspeed_mm/fsdp/train/trainer.py` | ltx2 | Standalone FSDP2 trainer, no Megatron |
+| Accelerate+DeepSpeed | `accelerate launch` | flux, sd3, sdxl, sana, hidream (all diffusers models) | Uses HF accelerate with DeepSpeed, completely different from Megatron |
+
+### Feature Extraction Matrix
+
+Not all models require feature extraction. Models that train on raw data skip this step entirely.
+
+| Script | Models | Notes |
+|---|---|---|
+| `get_wan_feature.py` | Wan2.1 | VAE + text encoder pre-encoding |
+| `get_hunyuan_feature.py` | HunyuanVideo | HunyuanVideo-specific VAE |
+| `get_sora_feature.py` | CogVideoX, StepVideo, OpenSoraPlan 1.3 | Shared extraction script |
+| `get_lumina_feature.py` | Lumina | Lumina-specific |
+| `get_vace_feature.py` | VACE | VACE-specific |
+| **Not needed** | wan2.2, OpenSoraPlan 1.5, ltx2, all diffusers models (flux, sd3, sdxl, sana, hidream) | Train directly on raw data |
+
+### Weight Converter Reference
+
+| Converter | Models |
+|---|---|
+| `WanConverter` | wan2.1, wan2.2 |
+| `HunyuanVideoConverter` | hunyuanvideo, hunyuanvideo_1.5 |
+| `CogVideoConverter` | cogvideox |
+| `OpenSoraPlanConverter` | opensoraplan1.3/1.5 |
+| `StepVideoConverter` | stepvideo |
+| `LuminaConverter` | lumina |
+| `VACEConverter` | vace |
+| **No converter needed** | diffusers models (flux, sd3, sdxl, sana, hidream) -- use HF weights directly |
+
+## Key Difference from VLM
+
+The generative model training pipeline includes an additional **feature extraction** step (for models that need it):
+
+```
+Data Preparation → Feature Extraction (VAE + TextEncoder) → Training → Inference
+```
+
+VLMs (Vision-Language Models) train directly from raw image/video inputs, whereas generative models first use a VAE to encode video into latent space features and a text encoder to encode text into vectors, then train a diffusion model in the feature space. Some newer models (wan2.2, ltx2, diffusers models) skip feature extraction and train on raw data directly.
+
+## Quick Start: Wan2.1-1.3B T2V (End-to-End, Flagship Example)
+
+Using Wan2.1-1.3B text-to-video as the flagship example (Megatron backend with feature extraction). This section walks through the complete training pipeline. To adapt for other models, refer to the "How to Train Any Generative Model" section above and the "Adaptation Notes" section below.
+
+### Step 0: Install Model-Specific Dependencies
+
+> **MANDATORY**: Wan2.1 requires `diffusers==0.33.1`. The base environment ships `diffusers==0.30.3`, which does **NOT** contain `AutoencoderKLWan` and will fail at feature extraction. You **must** upgrade before proceeding.
+
+```bash
+# Wan2.1 — upgrade diffusers (MANDATORY)
+pip install diffusers==0.33.1
+
+# IMPORTANT: After upgrading diffusers, verify core dependencies haven't been broken
+pip install numpy==1.26.0 pandas==2.0.3  # Pin back if upgraded
+python3 -c "import numpy, pandas, sklearn; print('Dependencies OK')"
+
+# Video decoder (DecordVideo is the official default for Wan2.1)
+# x86 architecture:
+pip install decord==0.6.0
+# ARM (aarch64) — build decord from source (apt-get may need retries due to network):
+apt-get update || (sleep 5 && apt-get update)  # retry if first attempt times out
+apt-get install -y cmake build-essential \
+    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavfilter-dev
+git clone --recursive https://github.com/dmlc/decord.git /tmp/decord
+cd /tmp/decord && mkdir build && cd build
+cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+cd /tmp/decord/python && pip install .
+# Note: libavfilter-dev is required — without it cmake fails with "FFMPEG_LIBAVFILTER-NOTFOUND"
+# Verify: python3 -c "import decord; print(decord.__version__)"
+```
+
+> Different models have significantly different dependency versions. See [references/per-model-deps.md](references/per-model-deps.md) for details.
+> It is strongly recommended to create a separate container for each model to avoid dependency conflicts.
+
+### Step 1: Weight Download and Conversion
+
+Download the `Wan-AI/Wan2.1-T2V-1.3B-Diffusers` weights from HuggingFace.
+
+**Weight conversion** (HuggingFace format -> MindSpeed-MM format):
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/
+```
+
+**When using Pipeline Parallelism (PP)**, you need to additionally specify the layer splitting scheme:
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.target_parallel_config.pp_layers '[[7,8,8,7]]'
+```
+
+> **Why `LOAD_PATH` uses `transformer/` (parent dir)**: `mm-convert hf_to_mm` writes `latest_checkpointed_iteration.txt` in `transformer/` and stores weights in `transformer/release/`. Megatron checkpoint loading reads `latest_checkpointed_iteration.txt` to resolve the actual subdirectory automatically. Set `LOAD_PATH` to `.../transformer/`, **not** `.../transformer/release/`.
+> For detailed information on weight conversion, refer to the `mindspeed-mm-weight-prep` Skill.
+
+### Step 2: Dataset Preparation
+
+Dataset directory structure:
+
+```
+<dataset>/
+├── data.json       # Video-text pair metadata
+└── videos/
+    ├── video0001.mp4
+    └── video0002.mp4
+```
+
+`data.json` format:
+
+```json
+[
+    {
+        "path": "videos/video0001.mp4",
+        "cap": "A cat playing with a ball in a garden.",
+        "num_frames": 81,
+        "fps": 24,
+        "resolution": {"height": 480, "width": 832}
+    },
+    {
+        "path": "videos/video0002.mp4",
+        "cap": "Ocean waves hitting the shore at sunset.",
+        "num_frames": 81,
+        "fps": 24,
+        "resolution": {"height": 480, "width": 832}
+    }
+]
+```
+
+**Field descriptions**:
+- `path`: Relative path to the video file (relative to the dataset root directory)
+- `cap`: Video description text
+- `num_frames`: Number of frames (Wan2.1 typically uses 81 frames)
+- `fps`: Frame rate
+- `resolution`: Resolution (height x width)
+
+Then edit `examples/wan2.1/feature_extract/data.txt`, with each line in the format:
+
+```
+<dataset_root_directory>,<data.json_path>
+```
+
+Example:
+
+```
+/home/dataset/wan_training,/home/dataset/wan_training/data.json
+```
+
+### Step 3: Feature Extraction
+
+> **Docker users**: If your container was not created with `--ipc=host` or `--shm-size=16g`, DataLoader workers will crash with `Bus error`. Set `--num-workers 0` in the script as a workaround.
+
+Feature extraction is a step unique to generative models. This step runs the VAE and text encoder on NPU to pre-encode raw video and text into feature vectors, so that training can directly use features without repeated encoding/decoding.
+
+**Configuration files** (3 files need to be modified):
+
+1. **`examples/wan2.1/feature_extract/model_t2v.json`**: Set the `from_pretrained` paths for the VAE and text encoder
+2. **`examples/wan2.1/feature_extract/data.json`**: Set `num_frames`, `max_height`, `max_width`, and the tokenizer's `from_pretrained` path
+3. **`mindspeed_mm/tools/tools.json`**: Set `sorafeature.save_path`, the output directory for extracted features
+
+**Launch feature extraction**:
+
+```bash
+bash examples/wan2.1/feature_extract/feature_extraction.sh
+```
+
+Underlying call: `torchrun ... mindspeed_mm/tools/feature_extraction/get_wan_feature.py`
+
+After extraction completes, the output structure is:
+
+```
+./sora_features/               ← sorafeature.save_path (feature dataset root)
+├── data.jsonl                 ← file paths are RELATIVE: "features/test_0000.pt"
+└── features/
+    ├── test_0000.pt
+    └── test_0001.pt
+```
+
+> **Path rule (important)**: `data_folder` in `feature_data.json` must point to the `save_path` root (e.g., `./sora_features/`), **NOT** `./sora_features/features/`. The `data.jsonl` already includes `features/` in its relative paths. Setting `data_folder` to the `features/` subdirectory causes double-nesting (`features/features/...`) and data loading failures.
+
+> For detailed feature extraction configuration, see [references/feature-extraction.md](references/feature-extraction.md).
+
+### Step 4: Training Configuration
+
+After feature extraction is complete, configure the training script.
+
+**Update data.txt**: Edit `examples/wan2.1/1.3b/t2v/data.txt` to point to the feature dataset root (e.g., `./sora_features`).
+
+**Key configuration files**:
+
+- **`feature_data.json`**: Dataset configuration. Set `data_folder` to `sorafeature.save_path` root (e.g., `./sora_features/`), `dataset_type: "feature"`, and tokenizer path
+- **`pretrain_model.json`**: Model architecture configuration, defines the diffusion scheduler and predictor (wandit) architecture parameters
+
+**Training script** `examples/wan2.1/1.3b/t2v/pretrain.sh` key parameters:
+
+```bash
+# Path configuration
+LOAD_PATH="./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/"
+SAVE_PATH="./output/wan2.1-1.3b-t2v/"
+
+# Parallelism strategy
+TP=1   # Tensor Parallelism
+PP=1   # Pipeline Parallelism
+VP=1   # Virtual Pipeline
+CP=1   # Context Parallelism
+MBS=1  # Micro Batch Size
+
+# Memory optimization (key parameters)
+--recompute-granularity full
+--recompute-method block
+--recompute-num-layers 20
+
+# Distributed optimizer
+--use-distributed-optimizer
+--overlap-grad-reduce
+--overlap-param-gather
+```
+
+### Step 5: Launch Training
+
+> **Docker users**: If your container was not created with `--ipc=host` or `--shm-size=16g`, DataLoader workers will crash with `Bus error`. Set `--num-workers 0` in the script as a workaround.
+
+```bash
+bash examples/wan2.1/1.3b/t2v/pretrain.sh
+```
+
+Entry script: `pretrain_sora.py`
+
+Training checkpoints are saved in the directory configured by `SAVE_PATH`.
+
+### Step 6: Inference Generation (Optional)
+
+After training completes, you can use the inference script to generate video from text prompts:
+
+```bash
+bash examples/wan2.1/1.3b/t2v/inference.sh
+```
+
+Entry script: `inference_sora.py`
+
+## Adaptation Notes for Other Models
+
+### Megatron Backend Models
+
+These models follow the same pipeline as Wan2.1 (feature extraction -> training via `pretrain_sora.py`):
+
+- **CogVideoX**: `examples/cogvideox/`, uses `CogVideoConverter`, feature extraction via `get_sora_feature.py`
+- **OpenSoraPlan 1.3**: `examples/opensoraplan1.3/`, uses `OpenSoraPlanConverter` (hf_to_mm), feature extraction via `get_sora_feature.py`
+- **OpenSoraPlan 1.5**: `examples/opensoraplan1.5/`, uses `OpenSoraPlanConverter` (source_to_mm), **no feature extraction** (trains on raw data)
+- **OpenSora 2.0**: `examples/opensora2.0/`
+- **HunyuanVideo**: `examples/hunyuanvideo/`, uses `HunyuanVideoConverter`, feature extraction via `get_hunyuan_feature.py`
+- **StepVideo**: `examples/stepvideo/`, uses `StepVideoConverter`, feature extraction via `get_sora_feature.py`
+- **Lumina**: uses `LuminaConverter`, feature extraction via `get_lumina_feature.py`
+
+### Megatron+FSDP2 Backend Models
+
+These models use `pretrain_sora.py` with `--use-torch-fsdp2` and require `CUDA_DEVICE_MAX_CONNECTIONS=2`:
+
+- **Wan2.2**: `examples/wan2.2/`, uses `WanConverter`, **NO feature extraction needed** (trains on raw data). Additional deps: `pip install -r examples/wan2.2/requirements.txt` (diffusers==0.35.1, peft==0.17.1)
+- **HunyuanVideo 1.5**: `examples/hunyuanvideo_1.5/`, uses `HunyuanVideoConverter`. Additional deps: `pip install -r examples/hunyuanvideo_1.5/requirements.txt` (transformers==4.57.1, diffusers==0.35.0)
+- **VACE**: `examples/vace/`, uses `VACEConverter`, feature extraction via `get_vace_feature.py`
+
+### FSDP2-Native Backend Models
+
+- **LTX2**: Uses `mindspeed_mm/fsdp/train/trainer.py` directly, **NO feature extraction needed**, no Megatron dependency
+
+### Accelerate+DeepSpeed Backend Models (Diffusers)
+
+These models use `accelerate launch` with DeepSpeed, **NOT** `pretrain_sora.py`. They use HuggingFace weights directly (no converter needed) and do NOT need feature extraction:
+
+- **FLUX**: `examples/diffusers/flux/`, text-to-image
+- **SD3**: `examples/diffusers/sd3/`, text-to-image
+- **SDXL**: `examples/diffusers/sdxl/`, text-to-image
+- **Sana**: `examples/diffusers/sana/`, text-to-image
+- **HiDream**: `examples/diffusers/hidream/`, text-to-image
+
+> Diffusers models have a completely different training flow from Megatron models. Read the shell scripts in `examples/diffusers/<model>/` to understand the specific launch command and config structure.
+
+## Post-Training
+
+MindSpeed-MM supports the following post-training optimization methods:
+
+| Method | Entry Script | Description |
+|---|---|---|
+| DPO | `posttrain_sora_dpo.py` | Direct Preference Optimization, used for aligning with human preferences |
+| GRPO | `posttrain_flux_dancegrpo.py` | Group Relative Policy Optimization |
+
+## Directory Structure Reference
+
+```
+MindSpeed-MM/
+├── pretrain_sora.py                 # Megatron/FSDP2 training entry point
+├── inference_sora.py                # Inference entry point
+├── posttrain_sora_dpo.py            # DPO post-training entry point
+├── posttrain_flux_dancegrpo.py      # GRPO post-training entry point
+├── mindspeed_mm/
+│   ├── fsdp/train/trainer.py        # FSDP2-native trainer (used by ltx2)
+│   └── tools/
+│       ├── tools.json               # Global config (sorafeature.save_path for feature output)
+│       └── feature_extraction/
+│           ├── get_wan_feature.py        # Wan2.1 feature extraction
+│           ├── get_hunyuan_feature.py    # HunyuanVideo feature extraction
+│           ├── get_sora_feature.py       # CogVideoX, StepVideo, OpenSoraPlan
+│           ├── get_lumina_feature.py     # Lumina feature extraction
+│           └── get_vace_feature.py       # VACE feature extraction
+└── examples/
+    ├── wan2.1/                      # Megatron backend
+    │   ├── feature_extract/
+    │   │   ├── feature_extraction.sh
+    │   │   ├── model_t2v.json
+    │   │   ├── data.json
+    │   │   └── data.txt
+    │   ├── 1.3b/t2v/
+    │   │   ├── pretrain.sh
+    │   │   ├── inference.sh
+    │   │   ├── data.txt
+    │   │   ├── feature_data.json
+    │   │   └── pretrain_model.json
+    │   └── 14b/t2v/
+    ├── wan2.2/                      # Megatron+FSDP2 backend
+    ├── hunyuanvideo/                # Megatron backend
+    ├── hunyuanvideo_1.5/            # Megatron+FSDP2 backend
+    ├── cogvideox/                   # Megatron backend
+    ├── opensoraplan1.3/             # Megatron backend
+    ├── opensoraplan1.5/             # Megatron backend
+    ├── opensora2.0/                 # Megatron backend
+    ├── stepvideo/                   # Megatron backend
+    ├── vace/                        # Megatron+FSDP2 backend
+    ├── ltx2/                        # FSDP2-native backend
+    └── diffusers/                   # Accelerate+DeepSpeed backend
+        ├── flux/
+        ├── sd3/
+        ├── sdxl/
+        ├── sana/
+        └── hidream/
+```
+
+## FAQ
+
+**Q: Feature extraction reports OOM** -- Reduce `max_height`/`max_width` or `num_frames` in `data.json`, or reduce `--nproc_per_node` in torchrun.
+
+**Q: Training loss does not converge** -- Check that `LOAD_PATH` points to `transformer/` (not model root), weight conversion completed successfully, and `dataset_type` in `feature_data.json` is `"feature"`.
+
+**Q: Inference generates all-black or noisy video** -- Confirm the inference script loads the correct checkpoint path and sufficient training steps have been completed.
+
+**Q: `mm-convert` command not found** -- Run `pip install -e .` to install MindSpeed-MM. `mm-convert` is a console entry point registered during installation.
+**Q: Feature extraction cannot read videos** -- Install decord: `pip install decord==0.6.0` on x86, or compile from source on ARM.
+**Q: `Communication_Error_Bind_IP_Port`** -- Stale process holding port. Kill with `lsof -i :29500` + `kill -9 <PID>`, or change `MASTER_PORT`.
+
+## References
+
+- [Model Delta Cards](references/model-delta-cards.md) - Execution checklists for non-flagship models (Wan2.2, HunyuanVideo, CogVideoX, Diffusers/FLUX)
+- [Per-Model Dependencies](references/per-model-deps.md) - Dependency versions and installation instructions for each generative model
+- [Feature Extraction Guide](references/feature-extraction.md) - Feature extraction configuration files, workflow, and troubleshooting
+- [Model Registry](../mindspeed-mm-pipeline/references/model-registry.md) - Complete lookup table for all models
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)

--- a/mindspeed-mm/mindspeed-mm-generative/references/feature-extraction.md
+++ b/mindspeed-mm/mindspeed-mm-generative/references/feature-extraction.md
@@ -1,0 +1,260 @@
+# Feature Extraction Guide
+
+Feature extraction is a core step in the generative model training pipeline. It uses a VAE and text encoder to pre-encode raw video/images and text into latent space features. During training, features are loaded directly, avoiding repeated encoding/decoding each epoch and significantly improving training efficiency.
+
+## Workflow Overview
+
+```
+Raw Video + Text Descriptions
+       │
+       ▼
+  ┌─────────────┐
+  │ VAE Encoder  │ → Video latent features (latents)
+  └─────────────┘
+  ┌──────────────┐
+  │ Text Encoder │ → Text embedding vectors (text embeddings)
+  └──────────────┘
+       │
+       ▼
+  Feature files (save_path)
+       │
+       ▼
+  pretrain_sora.py training
+```
+
+## Configuration Files
+
+Using Wan2.1 T2V as an example, feature extraction involves 3 configuration files and 1 data index file:
+
+### 1. data.txt -- Data Path Index
+
+**Location**: `examples/wan2.1/feature_extract/data.txt`
+
+Each line defines a dataset in the format:
+
+```
+<dataset_root_directory>,<data.json_path>
+```
+
+Example:
+
+```
+/home/dataset/wan_train,/home/dataset/wan_train/data.json
+/home/dataset/wan_val,/home/dataset/wan_val/data.json
+```
+
+**Notes**:
+- Multiple lines (i.e., multiple datasets) are supported
+- The video `path` field in `data.json` is relative to the dataset root directory
+- Ensure both the dataset root directory and data.json path use absolute paths
+
+### 2. data.json -- Data Configuration
+
+**Location**: `examples/wan2.1/feature_extract/data.json`
+
+> Note: This is the **feature extraction data configuration file**, not the user's dataset data.json.
+
+This file defines data processing parameters:
+
+```json
+{
+    "dataset_param": {
+        "dataset_type": "t2v",
+        "num_frames": 81,
+        "max_height": 480,
+        "max_width": 832,
+        "fps": 24
+    },
+    "tokenizer": {
+        "from_pretrained": "/path/to/weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/tokenizer/"
+    }
+}
+```
+
+**Key parameters**:
+
+| Parameter | Description | Notes |
+|---|---|---|
+| `num_frames` | Number of frames to extract | Must match the training configuration; Wan2.1 typically uses 81 |
+| `max_height` | Maximum height | Affects memory usage; reduce if OOM occurs |
+| `max_width` | Maximum width | Affects memory usage; reduce if OOM occurs |
+| `fps` | Frame rate | Should match the actual frame rate of the dataset |
+| `tokenizer.from_pretrained` | Tokenizer weight path | Points to the tokenizer subdirectory in the downloaded model weights |
+
+### 3. model_t2v.json / model_i2v.json -- Model Configuration
+
+**Location**: `examples/wan2.1/feature_extract/model_t2v.json` (t2v tasks use model_t2v.json, i2v tasks use model_i2v.json)
+
+Defines the model paths for the VAE and text encoder:
+
+```json
+{
+    "vae": {
+        "from_pretrained": "/path/to/weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/vae/"
+    },
+    "text_encoder": {
+        "from_pretrained": "/path/to/weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/text_encoder/"
+    }
+}
+```
+
+**t2v vs i2v differences**:
+- `model_t2v.json`: Only requires VAE + text encoder
+- `model_i2v.json`: May additionally require image encoder configuration (CLIP, etc.)
+
+### 4. tools.json -- Global Tool Configuration
+
+**Location**: `mindspeed_mm/tools/tools.json`
+
+Defines the output path for feature extraction:
+
+```json
+{
+    "sorafeature": {
+        "save_path": "./sora_features/"
+    }
+}
+```
+
+**Notes**:
+- `save_path` is the directory where feature files are saved
+- The `data.txt` for the training phase needs to point to this directory
+- Ensure this directory has sufficient disk space (feature files can be large)
+
+## Launching Feature Extraction
+
+### Using the Script
+
+```bash
+bash examples/wan2.1/feature_extract/feature_extraction.sh
+```
+
+### Underlying Script Call
+
+`feature_extraction.sh` internally uses `torchrun` to launch distributed feature extraction:
+
+```bash
+torchrun --nproc_per_node=8 \
+    mindspeed_mm/tools/feature_extraction/get_wan_feature.py \
+    --model_config examples/wan2.1/feature_extract/model_t2v.json \
+    --data_config examples/wan2.1/feature_extract/data.json \
+    --data_path examples/wan2.1/feature_extract/data.txt
+```
+
+> Actual parameters depend on the script contents; the above is illustrative.
+
+### Output
+
+After feature extraction completes, the `save_path` directory will contain feature files, including:
+- VAE-encoded video latent representations
+- Text encoder output text embeddings
+
+These feature files are loaded during training via `feature_data.json` (`dataset_type: "feature"`).
+
+## Referencing Features in Training Configuration
+
+After feature extraction is complete, update the training phase configuration:
+
+1. **`examples/wan2.1/1.3b/t2v/data.txt`**: Point to the feature directory
+
+```
+/path/to/sora_features,/path/to/sora_features/data.json
+```
+
+2. **`feature_data.json`**: Set the dataset type to feature
+
+```json
+{
+    "dataset_param": {
+        "dataset_type": "feature"
+    },
+    "tokenizer": {
+        "from_pretrained": "/path/to/tokenizer/"
+    }
+}
+```
+
+## Feature Extraction Differences by Model
+
+| Model | Feature Extraction Script Path | Model Config File | Feature Extraction Function |
+|---|---|---|---|
+| Wan2.1 | `examples/wan2.1/feature_extract/` | model_t2v.json / model_i2v.json | get_wan_feature.py |
+| HunyuanVideo | `examples/hunyuanvideo/feature_extract/` | Model config | Independent extraction script |
+| CogVideoX | `examples/cogvideox/feature_extract/` | Model config | CogVideoX-specific VAE |
+| FLUX | `examples/flux/feature_extract/` | Model config | t2i-specific workflow |
+| OpenSoraPlan | `examples/opensoraplan1.*/feature_extract/` | Model config | Independent extraction script |
+
+## Troubleshooting
+
+### DataLoader Bus Error in Docker
+
+**Symptom**: Workers crash with `Bus error (core dumped)` or the process is killed silently when using multiple DataLoader workers.
+
+**Cause**: Docker containers default to a 64 MB `/dev/shm` (shared memory). PyTorch DataLoader workers use shared memory to pass data back to the main process, and 64 MB is far too small for video feature extraction.
+
+**Solutions** (choose one):
+1. Recreate the container with `--ipc=host` or `--shm-size=16g`
+2. Set `--num-workers 0` in the feature extraction script to disable multiprocess data loading (slower but avoids the crash)
+
+```bash
+# Workaround: in the torchrun command or script, add --num-workers 0
+# Or check your current shm size:
+df -h /dev/shm
+```
+
+### Feature Extraction OOM (Out of Memory)
+
+**Symptom**: `RuntimeError: NPU out of memory`
+
+**Solutions**:
+1. Reduce `max_height` and `max_width` in `data.json` (e.g., from 480x832 to 256x448)
+2. Reduce `num_frames` (e.g., from 81 to 49)
+3. Reduce `--nproc_per_node` in `torchrun` (but this will slow down extraction)
+
+### Incorrect Model Weight Paths
+
+**Symptom**: `FileNotFoundError` or `OSError: Can't load model`
+
+**Troubleshooting**:
+- Confirm that the `from_pretrained` paths in `model_t2v.json` point to the correct subdirectories
+- The VAE path should point to the `vae/` directory containing `config.json` and model weight files
+- The text encoder path should point to the `text_encoder/` directory
+- The tokenizer path should point to the `tokenizer/` directory containing `tokenizer_config.json`
+
+### Video Read Failures
+
+**Symptom**: `ImportError: No module named 'decord'` or `RuntimeError: Failed to open video`
+
+**Troubleshooting**:
+- Confirm decord is installed (x86: `pip install decord==0.6.0`, ARM: compile from source)
+- Confirm video file paths are correct (root directory from `data.txt` + relative path from `data.json`)
+- Confirm video files are complete and not corrupted (check with `ffprobe`)
+
+### Empty or Incomplete Feature Files
+
+**Symptom**: Training reports `KeyError` or data loading fails
+
+**Troubleshooting**:
+- Check the feature extraction log for errors
+- Confirm the `save_path` directory in `tools.json` has write permissions
+- Confirm sufficient disk space is available
+- Re-run feature extraction to overwrite incomplete files
+
+### data.txt Format Errors
+
+**Symptom**: `IndexError` or `FileNotFoundError`
+
+**Troubleshooting**:
+- Each line must be in `<directory>,<json_path>` format, separated by a comma
+- Do not include extra spaces or blank lines
+- Use absolute paths
+
+### Confusing t2v and i2v
+
+**Symptom**: Model configuration does not match the task type
+
+**Troubleshooting**:
+- t2v tasks use `model_t2v.json`
+- i2v tasks use `model_i2v.json`
+- The `data.json` for i2v requires an additional image path field
+- The feature extraction script internally selects the encoding workflow based on the model configuration

--- a/mindspeed-mm/mindspeed-mm-generative/references/model-delta-cards.md
+++ b/mindspeed-mm/mindspeed-mm-generative/references/model-delta-cards.md
@@ -1,0 +1,145 @@
+# Model Delta Cards (vs. Wan2.1 baseline)
+
+Each card captures ONLY what differs from the standard Wan2.1 Megatron flow:
+`torchrun pretrain_sora.py` with `--mm-data/--mm-model/--mm-tool`, feature extraction via `get_sora_feature.py`, `WanConverter`, `CUDA_DEVICE_MAX_CONNECTIONS=1`.
+
+---
+
+### Wan2.2
+
+| Item | Value |
+|---|---|
+| Dir | `examples/wan2.2/{5B,A14B}/{t2v,ti2v,i2v}/` |
+| Backend | Megatron + **FSDP2** (not DistributedOptimizer) |
+| Entry script | `pretrain_sora.py` (same) |
+| Config format | `pretrain_model*.json` + `data.json` (same pattern) |
+| Weight conversion | `mm-convert WanConverter hf_to_mm` (same converter name, but weights are Wan2.2-specific) |
+| Feature extraction | **None** -- trains on raw video directly (no offline feature extraction step) |
+| Extra deps | `diffusers==0.35.1`, `peft==0.17.1` (own `requirements.txt`) |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=2` (not 1; required for FSDP2) |
+
+**Key differences from Wan2.1**:
+- Model sizes are **5B** and **A14B** (not 1.3B/14B)
+- A14B has dual transformers: `transformer` (high noise) + `transformer_2` (low noise), separate pretrain scripts `pretrain_high.sh` / `pretrain_low.sh`
+- Requires `--use-torch-fsdp2`, `--fsdp2-config-path`, `--untie-embeddings-and-output-weights`, `--ckpt-format torch_dcp`
+- FSDP2 saved weights need post-processing via `torch.distributed.checkpoint.format_utils dcp_to_torch` before inference
+- Supports optional DCP format for distributed ckpt loading (`mm-convert WanConverter mm_to_dcp`)
+- LoRA fine-tuning supported for A14B t2v with FSDP2 (`finetune_lora_{low/high}.sh`)
+- Install: `bash scripts/install.sh --megatron --msid 96bc0a3...` then `pip install -r examples/wan2.2/requirements.txt`
+
+**Quick start**:
+```bash
+bash scripts/install.sh --megatron --msid 96bc0a3bf3398bf45ac26e0bded95ee174ac449b
+pip install -r examples/wan2.2/requirements.txt
+mm-convert WanConverter hf_to_mm --cfg.source_path ./weights/.../transformer* --cfg.target_path ./weights/.../transformer*
+# Edit examples/wan2.2/5B/t2v/pretrain.sh (LOAD_PATH, SAVE_PATH, data paths)
+bash examples/wan2.2/5B/t2v/pretrain.sh
+```
+
+---
+
+### HunyuanVideo
+
+| Item | Value |
+|---|---|
+| Dir | `examples/hunyuanvideo/{t2v,i2v}/` |
+| Backend | Megatron (standard), supports TP + LayerZero |
+| Entry script | `pretrain_sora.py` (same) |
+| Config format | `model_hunyuanvideo.json` + `feature_data.json` |
+| Weight conversion | `mm-convert HunyuanVideoConverter --version {t2v,i2v} source_to_mm` (different converter) |
+| Feature extraction | **`get_hunyuan_feature.py`** (not `get_sora_feature.py`); separate `feature_extraction_i2v.sh` for I2V |
+| Extra deps | Megatron-LM `core_v0.12.1` (manual clone + copy); MindSpeed `6aff65e...` |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=1` (standard) |
+
+**Key differences from Wan2.1**:
+- Uses `HunyuanVideoConverter` (not `WanConverter`) with `--version t2v/i2v` flag
+- T2V requires additional text encoder conversion: `HunyuanVideoConverter --version t2v t2v_text_encoder`
+- Text encoders: `llava-llama-3-8b` + `clip-vit-large-patch14` (not a T5/CLIP pair)
+- Feature extraction is model-specific: `get_hunyuan_feature.py` at `mindspeed_mm/tools/feature_extraction/`
+- Trains on **pre-extracted features** (not raw video) -- `feature_data.json` points to extracted feature dirs
+- Supports TP-based parallelism + LayerZero (not FSDP2)
+- I2V LoRA fine-tuning supported via `pretrain_hunyuanvideo_lora.sh`
+- If TP>1 during training, weights must be merged before inference via `HunyuanVideoConverter source_to_mm`
+- Environment requires manual Megatron-LM + MindSpeed clone (not `scripts/install.sh`)
+
+**Quick start**:
+```bash
+# Feature extraction first
+bash examples/hunyuanvideo/feature_extract/feature_extraction.sh
+# Then train
+mm-convert HunyuanVideoConverter --version t2v source_to_mm --cfg.source_path <.../mp_rank_00/model_states.pt> --cfg.target_path ./ckpt/hunyuanvideo
+# Edit examples/hunyuanvideo/t2v/pretrain_hunyuanvideo.sh (LOAD_PATH, SAVE_PATH)
+bash examples/hunyuanvideo/t2v/pretrain_hunyuanvideo.sh
+```
+
+---
+
+### CogVideoX
+
+| Item | Value |
+|---|---|
+| Dir | `examples/cogvideox/{t2v_1.0,t2v_1.5,i2v_1.0,i2v_1.5}/` |
+| Backend | Megatron (standard), supports TP + PP + LayerZero |
+| Entry script | `pretrain_sora.py` (same) |
+| Config format | `model_cogvideox_{t2v,i2v}[_1.5].json` + `data.json` |
+| Weight conversion | `mm-convert CogVideoConverter --version {t2v,i2v} source_to_mm` (different converter) |
+| Feature extraction | **None by default** (VAE+T5 are inline); can optionally offload with `load_video_features: true` |
+| Extra deps | Megatron-LM `core_v0.12.1` (manual clone); MindSpeed `5176c6f...` (different commit from HunyuanVideo) |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=1` (standard); uses `GPUS_PER_NODE` (not `NPUS_PER_NODE`) |
+
+**Key differences from Wan2.1**:
+- Uses `CogVideoConverter` (not `WanConverter`) with `--version t2v/i2v`
+- Supports both v1.0 and v1.5 model versions with separate scripts and configs
+- SAT-based architecture: transformer weights from Tsinghua SAT format (`.pt` files)
+- Text encoder is **T5** (not CLIP/T5-XXL pair) -- tokenizer + text_encoder downloaded from CogVideoX-5b HF repo
+- Data format uses `data.jsonl` (not `data.json` array) with per-video `.txt` label files
+- Supports PP (pipeline parallelism) with `--optimization-level 2 --use-multiparameter-pipeline-model-parallel` and `pipeline_num_layers` in model config
+- Supports VAE CP (`cp_size` in ae config)
+- `head_dim` default is 64; changing to 128 is recommended for Ascend affinity
+- LoRA fine-tuning for 1.5 models: `finetune_cogvideox_lora_{t2v,i2v}_1.5.sh` with HF-format weights (`hf_to_mm`)
+- Weight resplit supported: `CogVideoConverter resplit` for changing TP/PP after training
+
+**Quick start**:
+```bash
+mm-convert CogVideoConverter --version t2v source_to_mm --cfg.source_path <transformer_weight> --cfg.target_path ./CogVideoX-5B-Converted --cfg.target_parallel_config.tp_size 4
+# Edit examples/cogvideox/t2v_1.5/pretrain_cogvideox_t2v_1.5.sh (LOAD_PATH, SAVE_PATH)
+# Edit examples/cogvideox/t2v_1.5/data.json (data_path, data_folder, VAE/T5 paths)
+bash examples/cogvideox/t2v_1.5/pretrain_cogvideox_t2v_1.5.sh
+```
+
+---
+
+### Diffusers (FLUX)
+
+| Item | Value |
+|---|---|
+| Dir | `examples/diffusers/flux/` (copied into HF diffusers repo's `examples/dreambooth/`) |
+| Backend | **Accelerate + DeepSpeed** (NOT Megatron) |
+| Entry script | **`train_dreambooth_flux.py`** (not `pretrain_sora.py`) |
+| Config format | `bf16_accelerate_config.yaml` (DeepSpeed ZeRO-2 config, not MM JSON) |
+| Weight conversion | **None** -- uses HF Diffusers weights directly |
+| Feature extraction | **None** -- online processing |
+| Extra deps | HF `diffusers` repo at commit `a98a839`, `deepspeed==0.17.2`, `peft==0.7.1`, `accelerate==1.7.0`, `transformers==4.47.1` |
+| Key env vars | `TOKENIZERS_PARALLELISM=false`, `OMP_NUM_THREADS=1` |
+
+**Key differences from Wan2.1**:
+- **Completely different stack**: Accelerate + DeepSpeed ZeRO-2, not Megatron torchrun
+- Launch via `accelerate launch --config_file <yaml>`, not `torchrun pretrain_sora.py`
+- No `mm-convert` weight conversion; loads HF model directly via `--pretrained_model_name_or_path`
+- No `--mm-data/--mm-model/--mm-tool` args; uses `--instance_data_dir` or `--dataset_name`
+- Requires manual code patches to HF diffusers source (`embeddings.py` float64->float32, `patch_flux.py` import)
+- Files live in HF diffusers repo, not MindSpeed-MM directly -- copy `examples/diffusers/flux/*` into cloned diffusers
+- Multi-node via accelerate yaml config (`deepspeed_multinode_launcher`, `num_machines`, `machine_rank`)
+- LoRA variant: `finetune_flux_dreambooth_lora_deepspeed_bf16.sh` with `train_dreambooth_lora_flux_advanced.py`
+- Image generation model (text-to-image), not video generation
+
+**Quick start**:
+```bash
+git clone https://github.com/huggingface/diffusers.git && cd diffusers
+git checkout a98a839de75f1ad82d8d200c3bc2e4ff89929081
+cp -r ../MindSpeed-MM/examples/diffusers/flux/* ./examples/dreambooth/
+pip install -e . && pip install -r examples/dreambooth/requirements_flux.txt
+# Apply code patches (embeddings.py, train_dreambooth_flux.py -- see README)
+cd examples/dreambooth
+bash finetune_flux_dreambooth_deepspeed_bf16.sh
+```

--- a/mindspeed-mm/mindspeed-mm-generative/references/per-model-deps.md
+++ b/mindspeed-mm/mindspeed-mm-generative/references/per-model-deps.md
@@ -1,0 +1,176 @@
+# Per-Model Dependencies for Generative Models
+
+This document lists the model-specific dependency requirements for each generative model supported by MindSpeed-MM. The base environment is covered by the `mindspeed-mm-env-setup` Skill.
+
+> **Key principle**: Different models have severe dependency version conflicts. It is strongly recommended to create a separate Docker container or virtual environment for each model.
+
+## Base Environment Dependencies (installed by default via pyproject.toml)
+
+| Package | Base Version |
+|---|---|
+| torch | 2.7.1 |
+| torch_npu | 2.7.1rc1 |
+| transformers | 4.57.0 |
+| diffusers | 0.30.3 |
+| peft | 0.7.1 |
+| accelerate | (base) |
+
+## Wan2.1
+
+**Override installation required**:
+
+> **MANDATORY**: `diffusers==0.33.1` is a mandatory override — the base `diffusers==0.30.3` does **NOT** contain `AutoencoderKLWan` and will fail at feature extraction. You must upgrade before any Wan2.1 work.
+
+```bash
+pip install diffusers==0.33.1
+pip install decord==0.6.0       # x86 architecture
+# ARM architecture: see "Common Dependency: decord" section below for full build instructions
+```
+
+| Package | Version | Difference from Base |
+|---|---|---|
+| diffusers | 0.33.1 | Mandatory override (base 0.30.3 incompatible) |
+| decord | 0.6.0 | New |
+
+**Notes**: Wan2.1 has the smallest dependency override footprint and is the easiest generative model to deploy.
+
+## Wan2.2
+
+**Override installation required**:
+
+```bash
+pip install -r examples/wan2.2/requirements.txt
+```
+
+| Package | Version | Difference from Base |
+|---|---|---|
+| diffusers | 0.35.1 | Upgraded |
+| peft | 0.17.1 | Upgraded (base 0.7.1) |
+| decord | 0.6.0 | New |
+
+**Conflict warnings**:
+- `diffusers==0.35.1` is incompatible with Wan2.1's `0.33.1`
+- `peft==0.17.1` differs significantly from base version `0.7.1`
+
+## HunyuanVideo
+
+**Override installation required**:
+
+```bash
+# Check dependency requirements under examples/hunyuanvideo/
+pip install diffusers==0.30.3   # Same as base version
+```
+
+**Notes**: The base HunyuanVideo version has mild dependency requirements. Prototype stage.
+
+## HunyuanVideo 1.5
+
+**Override installation required**:
+
+```bash
+pip install -r examples/hunyuanvideo_1.5/requirements.txt
+```
+
+| Package | Version | Difference from Base |
+|---|---|---|
+| transformers | 4.57.1 | Minor upgrade |
+| diffusers | 0.35.0 | Upgraded |
+
+**Conflict warnings**:
+- `diffusers==0.35.0` differs from Wan2.2's `0.35.1` (minor version difference may be compatible but is not guaranteed)
+- `transformers==4.57.1` has a small difference from base `4.57.0`
+
+## CogVideoX
+
+**Override installation required**:
+
+```bash
+# Check dependency requirements under examples/cogvideox/
+pip install diffusers==0.30.3   # Typically compatible with base version
+```
+
+**Notes**: CogVideoX 1.5 is friendly to the base environment dependencies. Released status.
+
+## FLUX (Text-to-Image)
+
+**Override installation required**:
+
+```bash
+# Check dependency requirements under examples/flux/
+```
+
+**Notes**: FLUX is the only t2i (text-to-image) model. Prototype stage. No video frame-related dependencies.
+
+## OpenSoraPlan 1.3 / 1.5
+
+**Override installation required**:
+
+```bash
+# Check dependency requirements under examples/opensoraplan1.3/ or examples/opensoraplan1.5/
+pip install decord==0.6.0       # Video decoder
+```
+
+**Notes**: Released status, dependencies are relatively stable.
+
+## StepVideo
+
+**Override installation required**:
+
+```bash
+# Check dependency requirements under examples/stepvideo/
+```
+
+**Notes**: Prototype stage.
+
+## Dependency Conflict Matrix
+
+| Dependency | Base | Wan2.1 | Wan2.2 | HunyuanVideo 1.5 | CogVideoX |
+|---|---|---|---|---|---|
+| diffusers | 0.30.3 | 0.33.1 | 0.35.1 | 0.35.0 | 0.30.3 |
+| peft | 0.7.1 | 0.7.1 | 0.17.1 | 0.7.1 | 0.7.1 |
+| transformers | 4.57.0 | 4.57.0 | 4.57.0 | 4.57.1 | 4.57.0 |
+
+**Conclusion**: Wan2.1 and CogVideoX can coexist in the same environment; Wan2.2 and HunyuanVideo 1.5 must have separate environments.
+
+## Common Dependency: decord (Video Decoder)
+
+All video generation models require decord to decode training videos.
+
+**x86 architecture**:
+
+```bash
+pip install decord==0.6.0
+```
+
+**ARM architecture** (e.g., Kunpeng processors commonly used in Ascend servers):
+
+decord does not provide pre-built ARM packages and must be compiled from source:
+
+```bash
+# Install build dependencies (libavfilter-dev is required — without it cmake fails with "FFMPEG_LIBAVFILTER-NOTFOUND")
+apt-get update && apt-get install -y cmake build-essential \
+    libavcodec-dev libavformat-dev libavutil-dev libswscale-dev libavfilter-dev
+
+git clone --recursive https://github.com/dmlc/decord.git /tmp/decord
+cd /tmp/decord && mkdir build && cd build
+cmake .. -DUSE_CUDA=0 -DCMAKE_BUILD_TYPE=Release
+make -j$(nproc)
+cd /tmp/decord/python && pip install .
+```
+
+## Post-Install Verification
+
+After installing or upgrading model-specific dependencies (especially `diffusers`), core packages such as `numpy` and `pandas` may be silently upgraded to incompatible versions. Pin them back and verify:
+
+```bash
+pip install numpy==1.26.0 pandas==2.0.3
+python3 -c "import numpy, pandas, sklearn; print('Dependencies OK')"
+```
+
+Run this check after every `pip install diffusers==...` or `pip install -r requirements.txt` to catch breakage early.
+
+## Installation Recommendations
+
+1. **Prefer the `requirements.txt` in the model directory**: If `examples/<model>/requirements.txt` exists, use it first
+2. **Verify installed versions**: After installation, confirm versions with `pip list | grep -E "diffusers|peft|transformers"`
+3. **Do not mix installations**: Installing dependencies for different models in the same environment will cause version overrides -- the later-installed model may work, but the earlier-installed model will break

--- a/mindspeed-mm/mindspeed-mm-pipeline/SKILL.md
+++ b/mindspeed-mm/mindspeed-mm-pipeline/SKILL.md
@@ -1,0 +1,312 @@
+---
+name: mindspeed-mm-pipeline
+description: MindSpeed-MM skill router and model index for Huawei Ascend NPU. Use when the user is uncertain which MindSpeed-MM skill to use, needs to choose between understanding/generative/omni/audio model categories, or wants an overview of the full training pipeline. Routes to the appropriate leaf skill based on model type.
+keywords:
+    - mindspeed-mm
+    - router
+    - model-index
+    - skill-selection
+    - overview
+---
+
+# MindSpeed-MM End-to-End Multimodal Training Pipeline
+
+This Skill is the **routing entry point** for all MindSpeed-MM Skills. It determines the model type based on user intent, routes to the corresponding Skill, and provides a complete pipeline overview.
+
+## Model Type Router
+
+```
+User Intent → Model Type Detection → Target Skill
+  "Train understanding model / VLM"       → mindspeed-mm-vlm
+  "Train generative model / video / image" → mindspeed-mm-generative
+  "Train omni model"                       → See examples/qwen2.5omni/README.md
+  "Train speech / TTS model"               → See examples/whisper/ or examples/cosyvoice3/README.md
+```
+
+**Routing Criteria**:
+
+| Keywords | Model Type | Target |
+|----------|-----------|--------|
+| VLM, vision-language, image-text understanding, OCR, Qwen2VL, InternVL, GLM4V | Understanding (VLM) | mindspeed-mm-vlm |
+| Video generation, image generation, t2v, t2i, i2v, Wan, CogVideoX, FLUX | Generative | mindspeed-mm-generative |
+| Omni, speech + vision + text | Omni | examples/qwen2.5omni/ |
+| Speech recognition, TTS, ASR, Whisper, CosyVoice | Audio | examples/whisper/ or examples/cosyvoice3/ |
+| DPO, GRPO, preference alignment, reinforcement learning | Post-training | See Post-training section |
+
+## Complete Workflow Overview
+
+### VLM Workflow
+
+```
+1. Environment Setup (mindspeed-mm-env-setup)
+→ 2. Model Dependency Installation (mindspeed-mm-vlm Step 0)
+→ 3. Weight Download + HF→MM Conversion (mindspeed-mm-weight-prep)
+→ 4. Data Preprocessing (MLLM JSON)
+→ 5. Training (pretrain_vlm.py)
+→ 6. Inference Validation (inference_vlm.py)
+→ 7. Evaluation (evaluate_vlm.py)
+→ 8. Weight Export MM→HF (optional)
+```
+
+**Inter-Stage Data Flow**:
+
+```
+model_from_hf/Qwen2.5-VL-7B-Instruct/   ← Step 3 download
+    ↓ mm-convert hf_to_mm
+ckpt/mm_path/Qwen2.5-VL-7B-Instruct/    ← Step 3 output
+    ↓ Used as the load path in model.json
+    ↓
+dataset/train.json + images/             ← Step 4 input (MLLM JSON format)
+    ↓ Used directly, no binary preprocessing needed
+    ↓
+saved_ckpt/                              ← Step 5 output
+    ↓ mm-convert mm_to_hf (optional)
+model_from_hf/.../converted/             ← Step 8 output
+```
+
+### Generative Model Workflow
+
+```
+1. Environment Setup (mindspeed-mm-env-setup)
+→ 2. Model Dependency Installation (mindspeed-mm-generative Step 0)
+→ 3. Weight Download + HF→MM Conversion (mindspeed-mm-weight-prep)
+→ 4. Data Preprocessing (video/image + caption JSON)
+→ 5. Feature Extraction (VAE + TextEncoder)  ← VLM does not have this step
+→ 6. Training (pretrain_sora.py)
+→ 7. Inference Generation (inference_sora.py)
+→ 8. Weight Export MM→HF (optional)
+```
+
+**Inter-Stage Data Flow**:
+
+```
+weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/  ← Step 3 download
+    ↓ mm-convert WanConverter hf_to_mm
+weights/.../transformer/                     ← Step 3 output (in-place conversion)
+    ↓
+dataset/videos/ + dataset/train.json         ← Step 4 input
+    ↓ Feature extraction script
+dataset/features/                            ← Step 5 output (VAE latents + text embeddings)
+    ↓ Used as training data input
+    ↓
+saved_ckpt/                                  ← Step 6 output
+    ↓ mm-convert WanConverter mm_to_hf (optional)
+converted_weights/                           ← Step 8 output
+```
+
+> **Key difference between VLM and generative models**: Generative models require an additional **feature extraction** step before training (VAE encodes video/images into latents, TextEncoder encodes text into embeddings). VLM does not have this step.
+
+## Full Model Index
+
+### Understanding Models (VLM)
+
+| Model | Specs | Entry Script | Status |
+|-------|-------|-------------|--------|
+| Qwen2VL | 2B/7B/72B | pretrain_vlm.py | Released |
+| Qwen2.5VL | 3B/7B/32B/72B | pretrain_vlm.py | Released |
+| Qwen3VL | 8B/30B/235B | pretrain_transformers.py | Released |
+| InternVL2.5 | 4B/78B | pretrain_internvl.py | Released |
+| InternVL3 | 8B/78B | pretrain_vlm.py | Released |
+| InternVL3.5 | 30B | pretrain_transformers.py | Released |
+| GLM4.1V | 9B | pretrain_vlm.py | Released |
+| GLM4.5V | -- | pretrain_transformers.py | Prototype |
+| DeepSeekVL2 | -- | pretrain_deepseekvl.py | Released |
+| DeepSeekOCR | -- | finetune_ocr.py (custom) | Prototype |
+| DeepSeekOCR2 | -- | finetune_ocr2.py (custom) | Prototype |
+| JanusPro | -- | -- | -- |
+| Ming | -- | finetune_vl.py (custom) | -- |
+| Bagel | -- | pretrain_omni.py | -- |
+
+### Generative Models
+
+| Model | Subtask | Entry Script | Status |
+|-------|---------|-------------|--------|
+| Wan2.1 | t2v/i2v/v2v/flf2v | pretrain_sora.py | Released |
+| Wan2.2 | t2v/i2v | pretrain_sora.py | Released |
+| HunyuanVideo | t2v | pretrain_sora.py | Prototype |
+| HunyuanVideo 1.5 | t2v | pretrain_sora.py | Prototype |
+| CogVideoX | t2v | pretrain_sora.py | Released |
+| FLUX | t2i | train_dreambooth_flux.py (diffusers) | Prototype |
+| OpenSoraPlan 1.3 | t2v | pretrain_sora.py | Released |
+| OpenSoraPlan 1.5 | t2v | pretrain_sora.py | Released |
+| StepVideo | t2v | pretrain_sora.py | Prototype |
+| LTX2 | t2v | mindspeed_mm/fsdp/train/trainer.py | -- |
+| Lumina-mGPT | -- | pretrain_lumina.py | Released |
+
+### Omni Models
+
+| Model | Entry Script | Status |
+|-------|-------------|--------|
+| Qwen2.5Omni | pretrain_vlm.py | Released |
+| Qwen3Omni | pretrain_transformers.py | Released |
+
+### Audio Models
+
+| Model | Entry Script | Status |
+|-------|-------------|--------|
+| Whisper | pretrain_whisper.py | -- |
+| CosyVoice3 | mindspeed_mm/fsdp/tasks/cosyvoice3/train.py | -- |
+| Qwen3TTS | mindspeed_mm/fsdp/train/trainer.py | -- |
+| FunASR | mindspeed_mm/fsdp/tasks/funasr/trainer.py | -- |
+
+### Post-training
+
+| Task | Script | Applicable Models |
+|------|--------|-------------------|
+| DPO | posttrain_qwen2vl_dpo.py | Qwen2VL |
+| DPO | posttrain_sora_dpo.py | Wan, Sora-like |
+| GRPO | posttrain_flux_dancegrpo.py | FLUX |
+| GRPO (verl) | verl_plugin/ | Qwen2.5VL |
+
+## Entry Script Selection Rules
+
+MindSpeed-MM has three entry script patterns:
+
+1. **Megatron-based unified entry**: `pretrain_vlm.py` (VLM), `pretrain_sora.py` (generative) — most models use these
+2. **Megatron-based model-specific entry**: `pretrain_internvl.py`, `pretrain_deepseekvl.py`, `pretrain_whisper.py`, `pretrain_lumina.py` — dedicated scripts for specific models
+3. **FSDP2-based entry**: `pretrain_transformers.py` or `mindspeed_mm/fsdp/train/trainer.py` or `mindspeed_mm/fsdp/tasks/<model>/train.py` — newer models (Qwen3VL, Qwen3Omni, LTX2, CosyVoice3, Qwen3TTS, FunASR)
+
+> **Always check the actual shell script** in `examples/<model_name>/` — do not assume from the model name.
+
+> New models should use the unified entry. Legacy models still use model-specific entries and are being migrated gradually.
+
+## Common Training Args Quick Reference
+
+The following parameters apply to all model types. For full parameter descriptions, see [references/common-args.md](references/common-args.md).
+
+### Parallelism Parameters
+
+| Parameter | Description | Typical Values |
+|-----------|-------------|----------------|
+| `--tensor-model-parallel-size` | Tensor parallelism degree (TP) | 1/2/4/8 |
+| `--pipeline-model-parallel-size` | Pipeline parallelism degree (PP) | 1/2/4/8 |
+| `--context-parallel-size` | Context parallelism degree (CP) | 1/2 |
+| `--expert-model-parallel-size` | Expert parallelism degree (EP, for MoE models) | 1/2/4 |
+
+### Batch and Sequence Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--micro-batch-size` | Number of samples per device per step |
+| `--global-batch-size` | Global batch size (= micro * DP * gradient_accum) |
+| `--seq-length` | Training sequence length |
+
+### Memory Optimization Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--recompute-granularity` | Recomputation granularity: `full` / `selective` |
+| `--recompute-method` | Recomputation method: `uniform` / `block` |
+| `--use-distributed-optimizer` | Use ZeRO-1 distributed optimizer |
+| `--sequence-parallel` | Sequence parallelism (reduces activation memory) |
+
+### Training Control Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `--train-iters` | Total training steps |
+| `--lr` | Initial learning rate |
+| `--min-lr` | Minimum learning rate |
+| `--lr-decay-style` | Learning rate decay strategy: `cosine` / `linear` |
+| `--weight-decay` | Weight decay |
+| `--bf16` | Use BF16 mixed precision |
+| `--use-flash-attn` | Enable FlashAttention |
+
+### Docker Runtime
+
+| Setting | Recommendation |
+|---|---|
+| `--ipc=host` | Required for DataLoader shared memory |
+| `--privileged` | Required for NPU device access |
+| `--num-workers` | Set to 0 if Docker shm is insufficient |
+| `MASTER_PORT` | Change if port conflict with stale processes |
+
+## FSDP2 vs Megatron Backend Selection
+
+MindSpeed-MM supports two distributed training backends:
+
+| Feature | Megatron | FSDP2 |
+|---------|----------|-------|
+| Maturity | Mature and stable | Newer |
+| Parallelism | Fine-grained TP/PP/CP/EP control | Automatic sharding |
+| Configuration | Command-line arguments | `--fsdp2-config-path` specifies YAML |
+| Supported Models | All models | Select models (Qwen3.5, CosyVoice3, Kimi-K2.5, etc.) |
+| Advantage | Flexible and tunable | Simple configuration, easy to get started |
+
+**Selection Guidelines**:
+- Use the **Megatron** backend for most scenarios (better documentation and examples)
+- If the model's official examples provide FSDP2 configuration and fine-grained parallelism tuning is not needed, FSDP2 is an option
+- FSDP2 uses `--fsdp2-config-path` to specify the configuration file, replacing Megatron's TP/PP/CP parameters
+
+## Parameter Consistency Rules
+
+The following parameters **must** be consistent between weight conversion and training:
+
+| Parameter | Weight Conversion (mm-convert) | Training Script |
+|-----------|:------------------------------:|:---------------:|
+| TP (`tensor-model-parallel-size` / `tp_size`) | Set | Must match |
+| PP (`pipeline-model-parallel-size` / `pp_layers`) | Set | Must match |
+| Model architecture | Determined by HF config | Must match |
+
+> Inconsistent parameters will cause weight loading failures or shape mismatch errors.
+
+## Pre-flight Checklist
+
+Verify each item before starting deployment:
+
+- [ ] Docker container created with `--privileged --ipc=host` (or `--shm-size=16g`)
+- [ ] Model-specific dependencies installed (diffusers version, decord for video models)
+- [ ] No stale torchrun processes holding MASTER_PORT
+- [ ] NPU available: `python -c "import torch_npu; print(torch.npu.is_available())"`
+- [ ] CANN environment activated: `npu-smi info`
+- [ ] MindSpeed-MM installed: `pip show mindspeed-mm`
+- [ ] Megatron module copied: `ls MindSpeed-MM/megatron/`
+- [ ] Model type determined (VLM / Generative / Omni / Audio)
+- [ ] Target model and specs confirmed
+- [ ] HF weights fully downloaded
+- [ ] TP/PP configuration determined and documented
+- [ ] Training data prepared
+
+## FAQ
+
+**Q: How do I determine which Skill to use?**
+
+Choose based on model type: use mindspeed-mm-vlm for VLM models, mindspeed-mm-generative for generative models. When in doubt, refer to the model index table above.
+
+**Q: What if different models have conflicting dependency versions?**
+
+MindSpeed-MM models have vastly different version requirements for transformers/diffusers/peft. It is strongly recommended to create a separate Docker container for each model. See the dependency conflict section in [mindspeed-mm-env-setup](../mindspeed-mm-env-setup/SKILL.md).
+
+**Q: Where can I find training scripts and configurations for a specific model?**
+
+Example scripts and YAML configurations for each model are located in the `MindSpeed-MM/examples/<model_name>/` directory.
+
+**Q: What is the difference between pretrain_vlm.py and pretrain_qwen2vl.py?**
+
+`pretrain_vlm.py` is the new unified entry point that differentiates models via YAML configuration. `pretrain_qwen2vl.py` is the legacy model-specific entry point. New models should use the unified entry; legacy models still use their dedicated entry points.
+
+**Q: Why do generative models need a feature extraction step?**
+
+Generative models (e.g., Wan, CogVideoX) do not directly ingest raw video/images during training. Instead, a VAE first encodes video into latent features, and a TextEncoder encodes text into embeddings. Training then loads these pre-extracted features directly. This avoids redundant encoding during training and significantly improves training efficiency.
+
+**Q: Training fails with `Communication_Error_Bind_IP_Port`**
+
+Stale process holding the port from a previous run. Kill zombie processes or change MASTER_PORT in the training script.
+
+```bash
+ps aux | grep torchrun | grep -v grep | awk '{print $2}' | xargs kill -9
+```
+
+## Related Skills
+
+- [mindspeed-mm-env-setup](../mindspeed-mm-env-setup/SKILL.md) - Base environment setup
+- [mindspeed-mm-weight-prep](../mindspeed-mm-weight-prep/SKILL.md) - Weight conversion (HF<->MM)
+- mindspeed-mm-vlm - VLM model training (understanding)
+- mindspeed-mm-generative - Generative model training (video/image)
+
+## Reference Resources
+
+- [Model Registry](references/model-registry.md) - Complete lookup table: model → backend, entry script, converter, feature extraction, requirements
+- [Common Training Args Reference](references/common-args.md) - GPT_ARGS, MOE_ARGS, OUTPUT_ARGS, environment variables
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)
+- [MindSpeed-MM Training Args Documentation](https://gitcode.com/ascend/MindSpeed-MM/blob/master/docs/zh/pytorch/args_readme.md)

--- a/mindspeed-mm/mindspeed-mm-pipeline/references/common-args.md
+++ b/mindspeed-mm/mindspeed-mm-pipeline/references/common-args.md
@@ -1,0 +1,258 @@
+# MindSpeed-MM Common Training Args Reference
+
+This document covers common parameters for MindSpeed-MM training scripts, sourced from `docs/zh/pytorch/args_readme.md`. Applicable to all model types (VLM, Generative, Omni, Audio).
+
+## GPT_ARGS (Core Training Parameters)
+
+### Parallelism
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--tensor-model-parallel-size` | int | 1 | Tensor parallelism degree (TP). Splits attention heads and FFN across devices. Value must evenly divide the number of attention heads. |
+| `--pipeline-model-parallel-size` | int | 1 | Pipeline parallelism degree (PP). Splits model layers across devices. Value must evenly divide the total number of layers. |
+| `--context-parallel-size` | int | 1 | Context parallelism degree (CP). Splits long sequences along the sequence dimension across devices. Used for ultra-long sequence training. |
+| `--expert-model-parallel-size` | int | 1 | Expert parallelism degree (EP). Distributes different experts across different devices in MoE models. |
+| `--sequence-parallel` | flag | false | Enable sequence parallelism. Further splits the sequence dimension on top of TP to reduce activation memory. Requires TP > 1. |
+
+**Parallelism Constraints**:
+- TP x PP x DP = total number of devices
+- DP (data parallelism) = total devices / (TP x PP), computed automatically
+- global_batch_size must be divisible by DP x micro_batch_size
+
+### Batch and Sequence
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--micro-batch-size` | int | required | Number of samples per device per step. Limited by NPU memory. |
+| `--global-batch-size` | int | required | Global batch size. Gradient accumulation steps = global / (micro x DP). |
+| `--seq-length` | int | required | Maximum training sequence length. Affects memory usage; must match the model's supported context length. |
+| `--max-position-embeddings` | int | -- | Maximum position encoding length. Usually equal to or greater than seq-length. Some models (e.g., RoPE) do not require this. |
+
+### Learning Rate and Optimizer
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--lr` | float | required | Initial learning rate. Pre-training typically 1e-4 ~ 5e-4; fine-tuning typically 1e-5 ~ 5e-5. |
+| `--min-lr` | float | 0 | Minimum learning rate. Lower bound for cosine decay. Usually set to 1/10 of lr. |
+| `--lr-decay-style` | str | linear | Learning rate decay strategy. Options: `cosine`, `linear`, `constant`. `cosine` is recommended. |
+| `--lr-warmup-fraction` | float | 0 | Learning rate warmup as a fraction of total steps. Typically 0.01 ~ 0.1. |
+| `--lr-warmup-iters` | int | 0 | Learning rate warmup steps. Use either this or `lr-warmup-fraction`, not both. |
+| `--weight-decay` | float | 0.01 | Weight decay coefficient. Pre-training commonly uses 0.1; fine-tuning commonly uses 0.01 ~ 0.1. |
+| `--adam-beta1` | float | 0.9 | Adam optimizer beta1. |
+| `--adam-beta2` | float | 0.999 | Adam optimizer beta2. 0.95 is recommended for bf16 training. |
+| `--clip-grad` | float | 1.0 | Gradient clipping threshold. Prevents gradient explosion. |
+
+### Precision and Performance
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--bf16` | flag | false | Use BF16 mixed precision training. Recommended for Ascend NPU. |
+| `--fp16` | flag | false | Use FP16 mixed precision training. May be needed for some models. Mutually exclusive with bf16. |
+| `--initial-loss-scale` | int | 2^32 | Initial loss scale for FP16 mixed precision. Not needed for bf16 training (bf16 does not use loss scaling). |
+| `--use-flash-attn` | flag | false | Enable FlashAttention. Significantly reduces attention memory usage; recommended. |
+| `--use-fused-rmsnorm` | flag | false | Enable fused RMSNorm. Improves computation efficiency. |
+| `--use-fused-swiglu` | flag | false | Enable fused SwiGLU. Improves FFN computation efficiency. |
+| `--use-fused-rotary-pos-emb` | flag | false | Enable fused RoPE. Improves positional encoding computation efficiency. |
+
+### Recomputation (Memory Optimization)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--recompute-granularity` | str | -- | Recomputation granularity. `full`: recompute entire Transformer layer; `selective`: recompute attention only. |
+| `--recompute-method` | str | -- | Recomputation method. `uniform`: distribute evenly; `block`: distribute by blocks. |
+| `--recompute-num-layers` | int | -- | Number of layers to recompute. Effective only with the `block` method. |
+| `--use-distributed-optimizer` | flag | false | Use ZeRO-1 distributed optimizer. Shards optimizer states across devices to reduce memory. Recommended. |
+
+### Checkpointing and Logging
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--save` | str | -- | Checkpoint save path. |
+| `--load` | str | -- | Checkpoint load path. Should point to the converted MM-format weights during training. |
+| `--save-interval` | int | -- | Save checkpoint every N steps. |
+| `--log-interval` | int | 100 | Print training log every N steps. |
+| `--eval-interval` | int | 1000 | Run evaluation every N steps. |
+| `--no-load-optim` | flag | false | Do not load optimizer state when loading checkpoint. Recommended for fine-tuning. |
+| `--no-load-rng` | flag | false | Do not load RNG state when loading checkpoint. Recommended for fine-tuning. |
+
+### Training Control
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--train-iters` | int | -- | Total training steps. Use either this or `--train-epochs`. |
+| `--train-epochs` | int | -- | Total training epochs. |
+| `--finetune` | flag | false | Fine-tuning mode. Loads pre-trained weights but resets the training step counter. |
+| `--no-save-optim` | flag | false | Do not save optimizer state in checkpoints. Saves disk space. |
+
+### Data
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--data-path` | str | -- | Training data path prefix. In MindSpeed-MM, this is usually specified in the YAML configuration. |
+| `--split` | str | 969,30,1 | Train/validation/test data split ratio. |
+| `--tokenizer-type` | str | -- | Tokenizer type. Use `PretrainedFromHF` for HuggingFace models. |
+| `--tokenizer-name-or-path` | str | -- | Tokenizer path. Points to the HF model directory (containing tokenizer.json). |
+
+## MOE_ARGS (MoE Model Parameters)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--num-experts` | int | -- | Total number of experts. E.g., DeepSeek-V2 uses 64. |
+| `--moe-router-topk` | int | -- | Number of experts selected per token. Usually 2 or 6. |
+| `--expert-model-parallel-size` | int | 1 | Expert parallelism degree. Distributes different experts across different devices. |
+| `--moe-token-dispatcher-type` | str | -- | Token dispatch method. Options: `alltoall`, `allgather`. |
+| `--moe-grouped-gemm` | flag | false | Enable grouped GEMM. Merges matrix multiplications from multiple experts. |
+| `--moe-router-load-balancing-type` | str | -- | Load balancing type. Options: `aux_loss`, `none`. |
+| `--moe-aux-loss-coeff` | float | 0 | Auxiliary load balancing loss coefficient. Usually 0.01. |
+
+## OUTPUT_ARGS (Output Control Parameters)
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--log-interval` | int | 100 | Log printing interval (steps). |
+| `--save-interval` | int | -- | Checkpoint save interval (steps). |
+| `--eval-interval` | int | 1000 | Evaluation interval (steps). |
+| `--eval-iters` | int | 100 | Number of steps per evaluation run. |
+| `--tensorboard-dir` | str | -- | TensorBoard log directory. |
+| `--tensorboard-log-interval` | int | 1 | TensorBoard logging interval. |
+| `--wandb-project` | str | -- | Weights & Biases project name. |
+| `--wandb-exp-name` | str | -- | Weights & Biases experiment name. |
+
+## FSDP2 Configuration Parameters
+
+When using the FSDP2 backend, specify a YAML configuration file via `--fsdp2-config-path`, replacing Megatron's TP/PP parameters.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `--fsdp2-config-path` | str | FSDP2 configuration file path. When specified, Megatron parallelism parameters like TP/PP are ignored. |
+
+FSDP2 configuration file example:
+
+```yaml
+fsdp:
+  sharding_strategy: FULL_SHARD      # Sharding strategy
+  mixed_precision:
+    param_dtype: bfloat16             # Parameter precision
+    reduce_dtype: float32             # Gradient reduction precision
+  cpu_offload: false                  # Whether to offload parameters to CPU
+```
+
+## Environment Variables
+
+| Variable | Description | Recommended Value |
+|----------|-------------|-------------------|
+| `CUDA_DEVICE_MAX_CONNECTIONS` | Maximum device connections | `1` (must be set) |
+| `HCCL_CONNECT_TIMEOUT` | HCCL communication connection timeout (seconds) | `1800` (recommended for multi-node training) |
+| `PYTORCH_NPU_ALLOC_CONF` | NPU memory allocation strategy | `expandable_segments:True` |
+| `HCCL_BUFFSIZE` | HCCL communication buffer size | `120` (MB, increase for large models) |
+| `HCCL_OP_BASE_FFTS_MODE_ENABLE` | HCCL operation optimization | `TRUE` |
+| `COMBINED_ENABLE` | Communication-computation overlap | `1` |
+| `ASCEND_LAUNCH_BLOCKING` | Synchronous execution mode (for debugging) | `0` (production) / `1` (debugging) |
+| `ASCEND_GLOBAL_LOG_LEVEL` | Ascend log level | `3` (ERROR) / `1` (INFO, for debugging) |
+| `TASK_QUEUE_ENABLE` | Asynchronous task queue | `2` (recommended) |
+| `MULTI_STREAM_MEMORY_REUSE` | Multi-stream memory reuse | `1` |
+
+### Environment Variable Setup Example
+
+```bash
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+export HCCL_CONNECT_TIMEOUT=1800
+export PYTORCH_NPU_ALLOC_CONF=expandable_segments:True
+
+# Performance optimization (optional)
+export HCCL_OP_BASE_FFTS_MODE_ENABLE=TRUE
+export COMBINED_ENABLE=1
+export TASK_QUEUE_ENABLE=2
+export MULTI_STREAM_MEMORY_REUSE=1
+```
+
+## LoRA Fine-tuning Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `--lora-r` | int | -- | LoRA rank. Common values: 8, 16, 32. Higher values increase fitting capacity but consume more memory. |
+| `--lora-alpha` | float | -- | LoRA scaling coefficient. Usually set to 2x lora-r. |
+| `--lora-target-modules` | list | -- | Modules to apply LoRA to. Common choices: `linear_qkv linear_proj linear_fc1 linear_fc2`. |
+| `--lora-load` | str | -- | Path to load existing LoRA weights. Used for continued training or inference. |
+
+## MindSpeed-MM Specific Configuration
+
+MindSpeed-MM model configuration is primarily specified via YAML files (`model.json` or `model.yaml`), rather than entirely through command-line arguments.
+
+### YAML Configuration Structure
+
+```yaml
+model:
+  model_name: "qwen2.5vl"
+  model_config:
+    ...                         # Model architecture configuration
+  load:
+    ckpt_dir: "ckpt/mm_path/..."  # Converted MM-format weight path
+  data:
+    dataset_type: "mllm"          # VLM uses mllm; generative models use sora_dataset, etc.
+    data_path: "dataset/train.json"
+    ...
+  training:
+    ...                         # Training hyperparameters
+```
+
+> Paths and parameters in YAML are merged with command-line arguments. Command-line arguments take higher priority.
+
+## Docker Runtime Considerations
+
+When running MindSpeed-MM training inside Docker containers, the following settings are critical:
+
+### Shared Memory (`--ipc=host` / `--shm-size`)
+
+PyTorch DataLoader workers use shared memory (`/dev/shm`) to pass data between processes. Docker containers default to a 64 MB `/dev/shm`, which is far too small for multimodal training.
+
+| Solution | Docker Flag | Description |
+|----------|------------|-------------|
+| Host IPC namespace (preferred) | `--ipc=host` | Shares the host's `/dev/shm`; no size limit from Docker |
+| Explicit shm size | `--shm-size=16g` | Sets `/dev/shm` to 16 GB inside the container |
+| Workaround | `--num-workers 0` in the training script | Disables worker processes; avoids shared memory entirely but slows data loading |
+
+If neither `--ipc=host` nor `--shm-size` is set and `--num-workers > 0`, training will crash with `Bus error (core dumped)`.
+
+### Privileged Mode for NPU Access
+
+Ascend NPU devices require access to `/dev/davinci*` and related kernel interfaces. The simplest approach is:
+
+```bash
+docker run --privileged ...
+```
+
+Alternatively, map devices explicitly (see [ascend-docker](../../../ascend-docker/SKILL.md) for details).
+
+### `MASTER_PORT` Conflicts
+
+`torchrun` binds to `MASTER_PORT` (default 6000 or as set in the training script). If a previous training run was killed without cleanup, the port may still be occupied.
+
+**Diagnosis**:
+```bash
+# Check if the port is in use
+ss -tlnp | grep <MASTER_PORT>
+
+# Find and kill stale torchrun processes
+ps aux | grep torchrun | grep -v grep | awk '{print $2}' | xargs kill -9
+```
+
+**Prevention**: Change `MASTER_PORT` in the training script to an unused port (e.g., 6001, 29500).
+
+## Parameter Tuning Recommendations
+
+### Steps to Take When Running Out of Memory
+
+1. Reduce `--micro-batch-size` (most direct)
+2. Enable `--recompute-granularity full` (trade compute for memory)
+3. Enable `--use-distributed-optimizer` (shard optimizer states)
+4. Enable `--sequence-parallel` (requires TP > 1)
+5. Increase PP (reduce per-device layer count)
+6. Use LoRA instead of full-parameter fine-tuning
+
+### Training Speed Optimization
+
+1. Increase `--micro-batch-size` (improve compute efficiency)
+2. Enable fused operators (`--use-flash-attn`, `--use-fused-rmsnorm`, `--use-fused-swiglu`)
+3. Adjust TP/PP ratio (typically TP within a single node, PP across nodes)
+4. Set performance environment variables (see environment variables section above)

--- a/mindspeed-mm/mindspeed-mm-pipeline/references/model-registry.md
+++ b/mindspeed-mm/mindspeed-mm-pipeline/references/model-registry.md
@@ -1,0 +1,113 @@
+# MindSpeed-MM Model Registry
+
+Complete lookup table for all supported models. Use this to find the right entry script, converter, config files, and README for any model.
+
+> **How to use**: Find your model below → note the backend, entry script, and converter → read `examples/<dir>/README.md` for full instructions.
+
+## VLM (Understanding) Models
+
+| Model | Dir | Backend | Entry Script | Converter | Requirements | Sizes |
+|---|---|---|---|---|---|---|
+| Qwen2.5VL | `qwen2.5vl` | Megatron | `pretrain_vlm.py` | `Qwen2_5_VLConverter` | base | 3B/7B/32B/72B |
+| Qwen2VL | `qwen2vl` | Megatron | `pretrain_vlm.py` | `Qwen2VLConverter` | base | 2B/7B/72B |
+| Qwen3VL | `qwen3vl` | FSDP2 | `pretrain_transformers.py` | `Qwen3VLConverter` (hf_to_dcp) | `requirements.txt` (git transformers) | 8B/30B/32B/235B |
+| InternVL2.5 | `internvl2.5` | Megatron | `pretrain_internvl.py` | `InternVLConverter` | base | 4B/78B |
+| InternVL3 | `internvl3` | Megatron | `pretrain_vlm.py` | `InternVLConverter` | base | 8B/78B |
+| InternVL3.5 | `internvl3.5` | FSDP2 | `pretrain_transformers.py` | `ExpertMergeDcpConverter` (DCP) | base | 30B (MoE) |
+| GLM4.1V | `glm4.1v` | Megatron | `pretrain_vlm.py` | `GlmConverter` | base | 9B |
+| GLM4.5V | `glm4.5v` | FSDP2 | `pretrain_transformers.py` | `ExpertMergeDcpConverter` (DCP) | base | 106B (MoE) |
+| DeepSeekVL2 | `deepseekvl2` | Megatron | `pretrain_deepseekvl.py` | `DeepSeekVLConverter` (hf_to_mm only) | base | MoE |
+| DeepSeekOCR | `deepseekocr` | Custom | `finetune_ocr.py` | None (HF direct) | `requirements.txt` (transformers==4.46.3) | -- |
+| DeepSeekOCR2 | `deepseekocr2` | Custom | `finetune_ocr2.py` | None (HF direct) | `requirements.txt` | -- |
+| JanusPro | `JanusPro` | Inference only | `multimodal_understanding.py` | None | Janus repo | 7B |
+| Ming | `ming` | Custom (native FSDP) | `finetune_vl.py` | None (HF direct) | `requirements.txt` | -- |
+| Bagel | `bagel` | FSDP2 | `pretrain_omni.py` | `BagelConverter` | base | 7B (MoT) |
+
+## Generative (Video/Image) Models
+
+| Model | Dir | Backend | Entry Script | Converter | Feature Extract | Requirements | Subtasks |
+|---|---|---|---|---|---|---|---|
+| Wan2.1 | `wan2.1` | Megatron | `pretrain_sora.py` | `WanConverter` | `get_wan_feature.py` | base + diffusers==0.33.1 | t2v/i2v/v2v/flf2v |
+| Wan2.2 | `wan2.2` | Megatron+FSDP2 | `pretrain_sora.py` | `WanConverter` | **None** (raw data) | `requirements.txt` | t2v/i2v/ti2v |
+| HunyuanVideo | `hunyuanvideo` | Megatron | `pretrain_sora.py` | `HunyuanVideoConverter` | `get_hunyuan_feature.py` | base | t2v/i2v |
+| HunyuanVideo 1.5 | `hunyuanvideo_1.5` | Megatron+FSDP2 | `pretrain_sora.py` | `HunyuanVideoConverter` | -- | `requirements.txt` | t2v/i2v |
+| CogVideoX | `cogvideox` | Megatron | `pretrain_sora.py` | `CogVideoConverter` | `get_sora_feature.py` | base | t2v |
+| OpenSoraPlan 1.3 | `opensoraplan1.3` | Megatron | `pretrain_sora.py` | `OpenSoraPlanConverter` | `get_sora_feature.py` | base | t2v/i2v |
+| OpenSoraPlan 1.5 | `opensoraplan1.5` | Megatron | `pretrain_sora.py` | `OpenSoraPlanConverter` | -- | base | t2v |
+| OpenSora 2.0 | `opensora2.0` | Megatron | `pretrain_sora.py` | `OpenSoraConverter` | -- | base | t2v |
+| StepVideo | `stepvideo` | Megatron | `pretrain_sora.py` | `StepVideoConverter` | `get_sora_feature.py` | base | t2v/i2v |
+| LTX2 | `ltx2` | FSDP2-native | `mindspeed_mm/fsdp/train/trainer.py` | None | None | base | t2v/t2av |
+| Lumina mGPT | `lumina` | Megatron | `pretrain_lumina.py` | `LuminaConverter` | `get_lumina_feature.py` | base | -- |
+| VACE | `vace` | Megatron+FSDP2 | `pretrain_sora.py` | `VACEConverter` | `get_vace_feature.py` | base | -- |
+| DanceGRPO | `dancegrpo` | Post-train | `posttrain_flux_dancegrpo.py` | -- | -- | base | GRPO |
+
+## Diffusers (Accelerate+DeepSpeed) Models
+
+| Model | Dir | Entry | Requirements |
+|---|---|---|---|
+| FLUX | `diffusers/flux` | `accelerate launch train_dreambooth_flux.py` | base |
+| FLUX Kontext | `diffusers/flux-kontext` | `accelerate launch` | base |
+| FLUX2 | `diffusers/flux2` | `accelerate launch` | base |
+| SD3 | `diffusers/sd3` | `accelerate launch` | base |
+| SDXL | `diffusers/sdxl` | `accelerate launch` | `requirements_sdxl_extra.txt` |
+| Sana | `diffusers/sana` | `accelerate launch` | base |
+| HiDream | `diffusers/hidream` | `accelerate launch` | base |
+| Qwen Image Edit | `diffsynth/qwen_image_edit` | `accelerate launch` | `requirements.txt` |
+
+> Diffusers models use HuggingFace Accelerate + DeepSpeed, NOT Megatron. No weight conversion or feature extraction needed. See each model's README for specific scripts.
+
+## Omni / Audio Models
+
+| Model | Dir | Backend | Entry Script | Requirements |
+|---|---|---|---|---|
+| Qwen2.5Omni | `qwen2.5omni` | Megatron | `pretrain_vlm.py` | base |
+| Qwen3Omni | `qwen3omni` | FSDP2-native | `mindspeed_mm/fsdp/train/trainer.py` | base |
+| Whisper | `whisper` | Megatron | `pretrain_whisper.py` | base |
+| CosyVoice3 | `cosyvoice3` | FSDP2-native | `mindspeed_mm/fsdp/tasks/cosyvoice3/train.py` | `requirements.txt` |
+| Qwen3TTS | `qwen3tts` | FSDP2-native | `mindspeed_mm/fsdp/train/trainer.py` | `requirements.txt` |
+| FunASR | `funasr` | FSDP2-native | `mindspeed_mm/fsdp/tasks/funasr/trainer.py` | `requirements.txt` |
+
+## Backend Quick Reference
+
+| Backend | Entry Script | Config Format | Key Env Var | Models |
+|---|---|---|---|---|
+| **Megatron** | `pretrain_vlm.py` / `pretrain_sora.py` / model-specific | JSON (data.json + model.json) | `CUDA_DEVICE_MAX_CONNECTIONS=1` | Most VLMs, Wan2.1, HunyuanVideo, CogVideoX, etc. |
+| **FSDP2** | `pretrain_transformers.py` / `pretrain_omni.py` (Bagel) | YAML | `CUDA_DEVICE_MAX_CONNECTIONS=2` | Qwen3VL, InternVL3.5, GLM4.5V, Bagel |
+| **Megatron+FSDP2** | `pretrain_sora.py` + `--use-torch-fsdp2` | JSON | `CUDA_DEVICE_MAX_CONNECTIONS=2` | Wan2.2, HunyuanVideo 1.5, VACE |
+| **FSDP2-native** | `mindspeed_mm/fsdp/train/trainer.py` or task-specific | YAML/JSON | varies | LTX2, Qwen3Omni, CosyVoice3, Qwen3TTS, FunASR |
+| **Accelerate** | `accelerate launch` | DeepSpeed JSON | -- | All diffusers models |
+| **Custom** | Model-specific `.py` in examples/ | CLI args | -- | DeepSeekOCR, Ming |
+
+## Weight Converter Quick Reference
+
+| Converter Class | Source File | Supported Operations | Used By |
+|---|---|---|---|
+| `Qwen2_5_VLConverter` | `checkpoint/vlm_model/converters/qwen2_5vl.py` | hf_to_mm, mm_to_hf, resplit | Qwen2.5VL |
+| `Qwen2VLConverter` | `checkpoint/vlm_model/converters/qwen2vl.py` | hf_to_mm, mm_to_hf, resplit | Qwen2VL |
+| `Qwen3VLConverter` | `checkpoint/vlm_model/converters/qwen3vl.py` | hf_to_dcp, dcp_to_hf | Qwen3VL |
+| `InternVLConverter` | `checkpoint/vlm_model/converters/internvl.py` | hf_to_mm, mm_to_hf, resplit | InternVL2.5, InternVL3 |
+| `ExpertMergeDcpConverter` | `checkpoint/vlm_model/converters/moe_expert.py` | hf_to_dcp, dcp_to_hf | InternVL3.5, GLM4.5V |
+| `GlmConverter` | `checkpoint/vlm_model/converters/glm.py` | hf_to_mm, mm_to_hf | GLM4.1V |
+| `DeepSeekVLConverter` | `checkpoint/vlm_model/converters/deepseekvl2.py` | hf_to_mm only | DeepSeekVL2 |
+| `BagelConverter` | `checkpoint/sora_model/bagel_converter.py` | hf_to_mm | Bagel |
+| `WanConverter` | `checkpoint/sora_model/wan_converter.py` | hf_to_mm, mm_to_hf, resplit | Wan2.1, Wan2.2 |
+| `HunyuanVideoConverter` | `checkpoint/sora_model/hunyuanvideo_converter.py` | source_to_mm, mm_to_hf | HunyuanVideo, HunyuanVideo 1.5 |
+| `CogVideoConverter` | `checkpoint/sora_model/cogvideo_converter.py` | source_to_mm, mm_to_hf | CogVideoX |
+| `OpenSoraPlanConverter` | `checkpoint/sora_model/opensoraplan_converter.py` | v1.3: hf_to_mm, resplit; v1.5: source_to_mm, resplit | OpenSoraPlan 1.3/1.5 |
+| `OpenSoraConverter` | `checkpoint/sora_model/opensora_converter.py` | hf_to_mm | OpenSora 2.0 |
+| `StepVideoConverter` | `checkpoint/sora_model/stepvideo_converter.py` | hf_to_mm | StepVideo |
+| `LuminaConverter` | `checkpoint/sora_model/lumina_converter.py` | hf_to_mm, mm_to_hf | Lumina |
+| `VACEConverter` | `checkpoint/sora_model/vace_converter.py` | hf_to_mm, mm_to_hf | VACE |
+| None | -- | -- | DeepSeekOCR, DeepSeekOCR2, Ming, JanusPro, all diffusers models |
+
+## Feature Extraction Scripts
+
+| Script | Path | Used By |
+|---|---|---|
+| `get_wan_feature.py` | `mindspeed_mm/tools/feature_extraction/` | Wan2.1 |
+| `get_hunyuan_feature.py` | `mindspeed_mm/tools/feature_extraction/` | HunyuanVideo |
+| `get_hunyuan15_feature.py` | `mindspeed_mm/tools/feature_extraction/` | -- (exists but not used in current examples) |
+| `get_sora_feature.py` | `mindspeed_mm/tools/feature_extraction/` | CogVideoX, StepVideo, OpenSoraPlan 1.3 |
+| `get_lumina_feature.py` | `mindspeed_mm/tools/feature_extraction/` | Lumina |
+| `get_vace_feature.py` | `mindspeed_mm/tools/feature_extraction/` | VACE |
+| **None needed** | -- | Wan2.2, OpenSora 2.0, LTX2, all diffusers, all audio/omni |

--- a/mindspeed-mm/mindspeed-mm-vlm/SKILL.md
+++ b/mindspeed-mm/mindspeed-mm-vlm/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: mindspeed-mm-vlm
+description: Universal VLM (vision-language understanding model) training guide for Huawei Ascend NPU using MindSpeed-MM. Covers all three framework patterns (Megatron, FSDP2, Custom trainers), weight conversion, dataset preparation (MLLM JSON format), fine-tuning, inference, and evaluation. Supports Qwen2.5VL, Qwen2VL, Qwen3VL, InternVL2.5/3/3.5, GLM4.1V, GLM4.5V, DeepSeekVL2, DeepSeekOCR, Ming, and more. Use when training or fine-tuning any multimodal understanding model on Ascend NPU.
+keywords:
+    - mindspeed-mm
+    - vlm
+    - multimodal understanding
+    - qwen2.5vl
+    - qwen3vl
+    - internvl
+    - glm4v
+    - deepseekvl
+    - finetune
+    - fine-tuning
+    - vision-language
+    - megatron
+    - fsdp2
+---
+
+# MindSpeed-MM VLM (Vision-Language Model) Training
+
+This Skill guides users through training multimodal understanding (VLM) models on Huawei Ascend NPU using MindSpeed-MM. It uses Qwen2.5VL-3B as the flagship example and covers the end-to-end fine-tuning workflow.
+
+## Prerequisites
+
+> **Critical**: For most VLMs (Qwen2.5VL, Qwen2VL, InternVL, GLM4V, DeepSeekVL2), follow the **manual install** flow below. Do NOT use `bash scripts/install.sh` — official MindSpeed-MM docs state it only fully supports Qwen3/Qwen3.5. (For Qwen3VL / Qwen3.5, use one-click install + `bash examples/qwen3_5/install_extensions.sh`.)
+
+### Step P1: Clone repositories
+
+```bash
+git clone https://gitcode.com/Ascend/MindSpeed-MM.git /root/workspace/MindSpeed-MM
+git clone https://github.com/NVIDIA/Megatron-LM.git /root/workspace/Megatron-LM
+cd /root/workspace/Megatron-LM && git checkout core_v0.12.1
+cp -r megatron /root/workspace/MindSpeed-MM/
+cd /root/workspace/MindSpeed-MM
+```
+
+### Step P2: Install PyTorch + torch_npu
+
+**Always use pre-built wheels** from [Ascend PyTorch Releases](https://gitcode.com/Ascend/pytorch/releases). Do **not** use `pip install torch==2.7.1` — aarch64 wheels on PyPI are unreliable.
+
+```bash
+# Download matching wheels from https://gitcode.com/Ascend/pytorch/releases
+# Replace cp310 with cp311 if using Python 3.11
+pip install torch-2.7.1-cp310-cp310-manylinux_2_28_aarch64.whl
+pip install torch_npu-2.7.1rc1-cp310-cp310-manylinux_2_28_aarch64.whl
+# For x86_64: same naming pattern with _x86_64 suffix
+
+# Required by torch_npu and other components:
+pip install numpy pyyaml scipy attrs decorator psutil
+```
+
+### Step P3: Install MindSpeed
+
+```bash
+git clone https://gitcode.com/Ascend/MindSpeed.git /root/workspace/MindSpeed
+cd /root/workspace/MindSpeed
+git checkout 93c45456c7044bacddebc5072316c01006c938f9
+pip install -r requirements.txt
+pip install -e .
+cd /root/workspace/MindSpeed-MM
+```
+
+### Step P4: Install MindSpeed-MM base dependencies
+
+```bash
+# Installs base stack from pyproject.toml: transformers==4.57.0, diffusers==0.30.3, peft==0.7.1, etc.
+pip install -e .
+```
+
+### Step P5: Activate CANN environment
+
+```bash
+source /usr/local/Ascend/cann/set_env.sh
+source /usr/local/Ascend/nnal/atb/set_env.sh
+```
+
+### Step P6: Smoke test
+
+```bash
+python3 -c "
+import torch, torch_npu
+assert torch.npu.is_available(), 'NPU not available'
+print(f'NPU count: {torch_npu.npu.device_count()}')
+import transformers, diffusers, mindspeed
+print(f'transformers={transformers.__version__}, diffusers={diffusers.__version__}')
+"
+```
+
+**Then proceed to Step 0** below for model-specific dependencies. For Qwen2.5VL the base is sufficient; other models need overlays (see Step 0 table).
+
+For detailed troubleshooting and alternative install paths, see [mindspeed-mm-env-setup](../mindspeed-mm-env-setup/SKILL.md).
+
+## Supported VLM Models
+
+| Model | Framework | Entry Script | Sizes | Status |
+|-------|-----------|-------------|-------|--------|
+| Qwen2.5VL | Megatron | pretrain_vlm.py | 3B/7B/32B/72B | Released |
+| Qwen2VL | Megatron | pretrain_vlm.py | 2B/7B/72B | Released |
+| Qwen3VL | FSDP2 | pretrain_transformers.py | 8B/30B/32B/235B | Released |
+| InternVL2.5 | Megatron | pretrain_internvl.py | 4B/78B | Released |
+| InternVL3 | Megatron | pretrain_vlm.py | 8B/78B | Released |
+| InternVL3.5 | FSDP2 | pretrain_transformers.py | -- | Released |
+| GLM4.1V | Megatron | pretrain_vlm.py | 9B | Released |
+| GLM4.5V | FSDP2 | pretrain_transformers.py | -- | Released |
+| DeepSeekVL2 | Megatron | pretrain_deepseekvl.py | -- | Released |
+| DeepSeekOCR | Custom | finetune_ocr.py | -- | Prototype |
+| DeepSeekOCR2 | Custom | finetune_ocr2.py | -- | Prototype |
+| Ming | Custom | finetune_vl.py | -- | Prototype |
+
+> **Entry Script Note**: VLM models use different entry scripts. Check the shell script in `examples/<model_name>/` for the exact command — do not assume from the model name.
+
+## How to Train Any VLM Model
+
+The workflow for training **any** VLM model in MindSpeed-MM follows a universal pattern:
+
+1. **Find the example**: Look in `examples/<model_name>/` for available shell scripts (finetune, pretrain, inference, evaluate)
+2. **Read the shell script**: Identify the entry script, config files, and parallelism settings
+3. **Check weight conversion**: Determine if the model needs `mm-convert` (Megatron models), DCP conversion (FSDP2 models), or uses HF weights directly (custom trainer models)
+4. **Modify config files**: Update data paths and weight paths in the config files (JSON or YAML depending on the framework)
+5. **Launch the shell script**: `bash examples/<model_name>/finetune_<model>_<size>.sh`
+
+For other models, adapt the Qwen2.5VL quick start below. Use the [Model Registry](../mindspeed-mm-pipeline/references/model-registry.md) to look up the exact entry script, converter, and backend for your target model.
+
+### Framework Patterns
+
+All VLM models in MindSpeed-MM follow one of three framework patterns:
+
+**Pattern 1: Megatron** (Qwen2.5VL, Qwen2VL, InternVL2.5, InternVL3, GLM4.1V, DeepSeekVL2)
+```bash
+# Uses JSON config files: data.json + model.json
+# Weight conversion: mm-convert <Converter> hf_to_mm
+torchrun $DISTRIBUTED_ARGS pretrain_vlm.py \
+  --mm-data examples/<model>/data.json \
+  --mm-model examples/<model>/model.json \
+  --load $MM_WEIGHT_PATH ...
+```
+
+**Pattern 2: FSDP2** (Qwen3VL, InternVL3.5, GLM4.5V)
+```bash
+# Uses YAML config file; requires CUDA_DEVICE_MAX_CONNECTIONS=2
+# Weight conversion: mm-convert <Converter> hf_to_dcp
+# MoE models may need: --init-model-with-meta-device
+CUDA_DEVICE_MAX_CONNECTIONS=2 torchrun $DISTRIBUTED_ARGS pretrain_transformers.py \
+  --fsdp2-config-path examples/<model>/fsdp2_config.yaml ...
+```
+
+**Pattern 3: Custom Trainers** (DeepSeekOCR, DeepSeekOCR2, Ming)
+```bash
+# Standalone entry scripts; uses HF weights directly (no conversion needed)
+torchrun $DISTRIBUTED_ARGS examples/<model>/finetune_<model>.py <args>
+```
+
+## Quick Start: Qwen2.5VL-3B Fine-Tuning (End-to-End)
+
+> **This is the flagship Megatron-pattern example.** For other models, follow the same workflow structure but use configs and scripts from `examples/<model_name>/`. FSDP2 models use YAML configs instead of JSON; Custom trainer models skip weight conversion entirely. See the "Framework Patterns" section above.
+
+### Step 0: Model-Specific Dependencies
+
+Different VLM models have different version requirements for libraries such as transformers. Some of these requirements conflict, so environment isolation is necessary.
+
+| Model | Additional Dependencies | Notes |
+|-------|------------------------|-------|
+| Qwen2.5VL | None required | Base environment is sufficient |
+| Qwen3VL | `pip install -r examples/qwen3vl/requirements.txt` | Requires latest transformers; may conflict with other models |
+| DeepSeekOCR | `pip install -r examples/deepseekocr/requirements.txt` | Downgrades transformers to 4.46.3; **must use isolated environment** |
+| InternVL3 | None required | Base environment is sufficient (directory is `examples/internvl3/`, no extra requirements.txt) |
+
+> **Important**: Qwen3VL and DeepSeekOCR have conflicting transformers version requirements. If you need to support both, use separate Docker containers or conda environments. See [per-model-deps.md](references/per-model-deps.md) for details.
+
+### Step 1: Weight Download and Conversion
+
+#### 1.1 Download HuggingFace Weights
+
+```bash
+# Download from HuggingFace (requires proxy)
+http_proxy=http://127.0.0.1:58232 https_proxy=http://127.0.0.1:58232 \
+  huggingface-cli download Qwen/Qwen2.5-VL-3B-Instruct \
+  --local-dir ckpt/hf_path/Qwen2.5-VL-3B-Instruct
+```
+
+#### 1.2 HF to MM Format Conversion
+
+MindSpeed-MM uses its own weight format (MM format). Weights must be converted before training.
+
+```bash
+mm-convert Qwen2_5_VLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [[36]] \
+  --cfg.parallel_config.vit_pp_layers [[32]] \
+  --cfg.parallel_config.tp_size 1
+```
+
+Key parameter descriptions:
+
+| Parameter | Description |
+|-----------|-------------|
+| `--cfg.mm_dir` | Output directory for converted MM format weights |
+| `--cfg.hf_config.hf_dir` | Source HF weight directory |
+| `--cfg.parallel_config.llm_pp_layers` | PP partitioning for LLM layers. `[[36]]` means all 36 layers on one device when PP=1 |
+| `--cfg.parallel_config.vit_pp_layers` | PP partitioning for ViT layers. `[[32]]` means all 32 layers on one device when PP=1 |
+| `--cfg.parallel_config.tp_size` | Tensor parallelism degree; must match the training configuration |
+
+> **Important**: `llm_pp_layers` and `vit_pp_layers` must match the `pipeline_num_layers` in model.json. When PP > 1, you need to split the layer counts, e.g., `[[18,18]]` for PP=2.
+
+#### 1.3 Converters for Different Models
+
+| Model | Converter Name | Direction | Notes |
+|-------|---------------|-----------|-------|
+| Qwen2.5VL | `Qwen2_5_VLConverter` | hf_to_mm / mm_to_hf | See example above |
+| Qwen2VL | `Qwen2VLConverter` | hf_to_mm / mm_to_hf | Same pattern as Qwen2.5VL |
+| Qwen3VL | `Qwen3VLConverter` | hf_to_dcp / dcp_to_hf | **FSDP2**: uses DCP format, not mm format |
+| Qwen3VL (Megatron) | `Qwen3VLMegatronConverter` | hf_to_mm / mm_to_hf | Alternative Megatron-path converter |
+| InternVL2.5/3 | `InternVLConverter` | hf_to_mm / mm_to_hf | `--cfg.parallel_config.vit_pp_layers [[45]]` |
+| InternVL3.5 | `ExpertMergeDcpConverter` | hf_to_dcp / dcp_to_hf | FSDP2 path; MoE model uses expert merge converter |
+| DeepSeekVL2 | `DeepSeekVLConverter` | hf_to_mm only | `mm_to_hf` is unimplemented (stub). Note MoE expert layers |
+| GLM4.1V | `GlmConverter` | hf_to_mm / mm_to_hf | Generic Megatron converter |
+| GLM4.5V | `ExpertMergeDcpConverter` | hf_to_dcp / dcp_to_hf | FSDP2 path; MoE model uses expert merge converter |
+| MoE models | `ExpertMergeDcpConverter` | merge / split | Merge/split MoE expert weights for DCP checkpoints |
+| DeepSeekOCR/OCR2 | *None* | -- | Uses HF weights directly; no conversion needed |
+| Ming | *None* | -- | Uses HF weights directly; no conversion needed |
+
+### Step 2: Dataset Preparation
+
+VLM training uses the **MLLM JSON format**. This example uses COCO2017 + LLaVA-Instruct-150K.
+
+#### 2.1 Download Data
+
+```bash
+# 1. Download COCO2017 training images
+mkdir -p data/COCO2017/train2017
+# Extract to data/COCO2017/train2017/
+
+# 2. Download LLaVA-Instruct-150K
+# Download llava_instruct_150k.json to data/
+```
+
+#### 2.2 Convert to MLLM Format
+
+> **Important**: The conversion script uses hardcoded relative paths. It expects `./data/llava_instruct_150k.json` as input and `./data/COCO2017/train2017/` for image lookup. Run it from the MindSpeed-MM root directory, and ensure data is at `./data/` (or create symlinks).
+
+```bash
+cd /root/workspace/MindSpeed-MM  # Must run from repo root
+python examples/qwen2vl/llava_instruct_2_mllm_demo_format.py
+```
+
+Output: `data/mllm_format_llava_instruct_data.json`
+
+The script converts LLaVA format (`conversations`/`image`) to MLLM format (`messages`/`images`), which is what MindSpeed-MM expects.
+
+#### 2.3 Data Directory Structure
+
+```
+data/
+├── COCO2017/train2017/          # Image files
+│   ├── 000000000009.jpg
+│   ├── 000000000025.jpg
+│   └── ...
+├── llava_instruct_150k.json     # Original data (for conversion)
+└── mllm_format_llava_instruct_data.json  # MLLM format (for training)
+```
+
+> **Field name matching**: The field names in your data JSON must match the `attr` section in data.json config. Default mapping: `messages` for conversations, `images` for image paths. Using different field names (e.g., `conversations` instead of `messages`) will cause `KeyError`.
+
+> For detailed MLLM JSON format specifications, see [data-format.md](references/data-format.md).
+
+### Step 3: Configuration Files
+
+Qwen2.5VL-3B fine-tuning requires two JSON configuration files:
+
+#### 3.1 data.json (Data Configuration)
+
+Path: `examples/qwen2.5vl/data_3b.json`
+
+```json
+{
+    "dataset_param": {
+        "dataset_type": "huggingface",
+        "preprocess_parameters": {
+            "model_name_or_path": "./ckpt/hf_path/Qwen2.5-VL-3B-Instruct"
+        },
+        "basic_parameters": {
+            "dataset_dir": "./data",
+            "dataset": "./data/mllm_format_llava_instruct_data.json",
+            "cache_dir": "./data/cache_dir"
+        }
+    }
+}
+```
+
+**Must edit before running** — update these 3 paths to match your environment:
+
+| Field | Description | What to set |
+|-------|-------------|-------------|
+| `model_name_or_path` | **Original HF weights** (not MM-converted) | e.g., `/home/weights/Qwen2.5-VL-3B-Instruct` |
+| `dataset` | MLLM format JSON path | e.g., `./data/mllm_format_llava_instruct_data.json` |
+| `cache_dir` | Data preprocessing cache (LOCAL path) | e.g., `./data/cache_dir` — **not NFS/shared mount** |
+
+> **Multi-node Note**: `cache_dir` stores preprocessing cache. During multi-node training, each node must use a local path and must not point to an NFS shared directory, otherwise concurrent write conflicts will occur.
+
+#### 3.2 model.json (Model Configuration)
+
+Path: `examples/qwen2.5vl/model_3b.json`
+
+model.json defines three components of the model architecture:
+
+| Component | Type | Layers | Description |
+|-----------|------|--------|-------------|
+| `image_encoder` | qwen2vit | 32 | Vision encoder (ViT) |
+| `vision_projector` | lnmlp | -- | Vision-to-text projection layer |
+| `text_decoder` | qwen2_5_lm | 36 | Text decoder (LLM) |
+
+> **Important**: The `pipeline_num_layers` field defines the PP partitioning scheme and must exactly match the `llm_pp_layers` / `vit_pp_layers` used during weight conversion.
+
+### Step 4: Training Script Configuration
+
+The training launch script is located at `examples/qwen2.5vl/finetune_qwen2_5_vl_3b.sh`.
+
+#### 4.1 Key Variables
+
+```bash
+LOAD_PATH="ckpt/mm_path/Qwen2.5-VL-3B-Instruct"   # Converted MM weights
+SAVE_PATH="save_dir"                                 # Training output save path
+DATA_CONFIG="examples/qwen2.5vl/data_3b.json"        # Data configuration
+MODEL_CONFIG="examples/qwen2.5vl/model_3b.json"      # Model configuration
+TP=1; PP=1; CP=1                                      # Parallelism configuration
+MBS=1; GRAD_ACC_STEP=32                               # Batch size configuration
+```
+
+#### 4.2 Important Training Parameters
+
+| Parameter | Description | Typical Value |
+|-----------|-------------|---------------|
+| `--tensor-model-parallel-size` | Tensor parallelism degree (TP) | 1-8 |
+| `--pipeline-model-parallel-size` | Pipeline parallelism degree (PP) | 1-4 |
+| `--context-parallel-size` | Context parallelism degree (CP) | 1-2 |
+| `--micro-batch-size` | Micro-batch size per NPU | 1 |
+| `--global-batch-size` | Global batch size | 32 |
+| `--lr` | Learning rate | 1e-5 to 2e-5 |
+| `--train-iters` | Number of training iterations | 1000-5000 |
+| `--bf16` | BFloat16 precision | Always recommended |
+| `--use-distributed-optimizer` | Distributed optimizer | Recommended for multi-device |
+| `--no-load-optim` | Do not load optimizer state | Required for fine-tuning |
+| `--no-load-rng` | Do not load RNG state | Required for fine-tuning |
+
+#### 4.3 Docker Users
+
+**Docker users**: If your container lacks `--ipc=host` or `--shm-size=16g`, set `--num-workers 0` in the training script to avoid `Bus error` from DataLoader workers.
+
+#### 4.4 Launch Command
+
+```bash
+torchrun $DISTRIBUTED_ARGS pretrain_vlm.py $GPT_ARGS $MM_ARGS $OUTPUT_ARGS
+```
+
+> **Note**: Qwen2.5VL uses `pretrain_qwen2vl.py` or `pretrain_vlm.py` as the entry point. Different versions of the script may vary; refer to the actual script in your installation.
+
+#### 4.5 Single-Node vs Multi-Node
+
+```bash
+# Single node, 8 NPUs
+MASTER_ADDR=localhost
+NNODES=1
+NODE_RANK=0
+
+# Multi-node (2 nodes)
+# Node 0 (master node)
+MASTER_ADDR=192.168.1.100  # Master node IP
+NNODES=2
+NODE_RANK=0
+
+# Node 1
+MASTER_ADDR=192.168.1.100  # Same as above; points to the master node
+NNODES=2
+NODE_RANK=1
+```
+
+### Step 5: Launch Training
+
+```bash
+bash examples/qwen2.5vl/finetune_qwen2_5_vl_3b.sh
+```
+
+Key metrics to monitor in training logs:
+- `lm loss`: Language model loss; should decrease steadily
+- `grad norm`: Gradient norm; excessively large values may indicate the need to adjust the learning rate
+- `iteration time`: Time per training iteration
+
+### Step 6: Inference Verification (Optional)
+
+After training, you can run inference verification. Note: no 3B-specific inference script exists; use the 7B script and adjust the model/config paths:
+
+```bash
+# Edit inference_qwen2_5_vl_7b.sh to point to your 3B checkpoint, then:
+bash examples/qwen2.5vl/inference_qwen2_5_vl_7b.sh
+```
+
+Inference requires an inference JSON configuration (`inference_qwen2_5_vl_7b.json`) specifying the model path and test images. The inference script uses the `inference_vlm.py` entry point.
+
+### Step 7: Evaluation (Optional)
+
+```bash
+# Similarly, use the 7B evaluation script with 3B paths:
+bash examples/qwen2.5vl/evaluate_qwen2_5_vl_7b.sh
+```
+
+> **Note**: Only 7B and 72B inference/evaluation scripts are provided. For 3B or 32B, copy and adapt the 7B scripts with the appropriate model config and checkpoint paths.
+
+## Recommended Parallelism Configurations by Model Size
+
+| Model Size | NPU Count | Recommended TP | Recommended PP | MBS |
+|------------|-----------|----------------|----------------|-----|
+| 3B | 1-8 | 1 | 1 | 1 |
+| 7B | 8 | 1-2 | 1-2 | 1 |
+| 32B | 8-16 | 4 | 2 | 1 |
+| 72B-78B | 16-32 | 8 | 2-4 | 1 |
+
+## Post-Training: DPO Preference Alignment
+
+Qwen2.5VL supports DPO post-training using the `posttrain_qwen2vl_dpo.py` entry point:
+
+```bash
+bash examples/qwen2vl/finetune_qwen2vl_72b_dpo.sh
+```
+
+See the relevant files in the `examples/qwen2vl/` directory for DPO configuration and data format details.
+
+## FAQ
+
+**Q: Training fails with `shape mismatch` after weight conversion**
+
+`pipeline_num_layers` does not match the `llm_pp_layers` / `vit_pp_layers` used during weight conversion. Check that the layer count configuration in model.json matches the parameters passed to the `mm-convert` command.
+
+**Q: Data loading hangs during multi-node training**
+
+`cache_dir` is set to an NFS shared mount path. Change it to a local path (e.g., `/tmp/cache_dir`) so each node preprocesses data independently.
+
+**Q: `transformers` version conflict**
+
+Different VLM models require different versions of transformers. Qwen3VL needs the latest version, while DeepSeekOCR needs 4.46.3. Use separate containers to isolate environments.
+
+**Q: Images fail to load during inference**
+
+Check that the image paths in the inference JSON are correct and that the image files exist in a supported format (JPEG/PNG).
+
+**Q: Training OOM (out of memory)**
+
+Reduce `--micro-batch-size` to 1, enable `--use-distributed-optimizer`, or increase TP/PP parallelism.
+
+**Q: Training fails with `Communication_Error_Bind_IP_Port`**
+
+A stale process from a previous run is holding the port. Fix:
+```bash
+ps aux | grep torchrun | grep -v grep | awk '{print $2}' | xargs kill -9
+# Or change MASTER_PORT in the training script
+```
+
+## Related Skills
+
+- [mindspeed-mm-env-setup](../mindspeed-mm-env-setup/SKILL.md) - MindSpeed-MM Environment Setup
+- [ascend-docker](../../ascend-docker/SKILL.md) - Ascend Docker Container Configuration
+- [hccl-test](../../hccl-test/SKILL.md) - Multi-Device Communication Testing
+
+## Reference Resources
+
+- [Model Delta Cards](references/model-delta-cards.md) - Execution checklists for non-flagship models (Qwen3VL, InternVL3.5, GLM4.5V, DeepSeekVL2, DeepSeekOCR, Ming)
+- [Model Dependency Configuration](references/per-model-deps.md) - Dependencies and version requirements for each VLM model
+- [Data Format Specification](references/data-format.md) - Detailed MLLM JSON format documentation
+- [Model Registry](../mindspeed-mm-pipeline/references/model-registry.md) - Complete lookup table for all models
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)

--- a/mindspeed-mm/mindspeed-mm-vlm/references/data-format.md
+++ b/mindspeed-mm/mindspeed-mm-vlm/references/data-format.md
@@ -1,0 +1,197 @@
+# MLLM JSON Data Format Specification
+
+MindSpeed-MM VLM training uses the **MLLM JSON format** as the unified data input format. This document provides a detailed specification of the format, field definitions, and conversion methods.
+
+## Format Overview
+
+MLLM JSON is a JSON file containing an array of objects, where each object represents a single training sample (single-turn or multi-turn conversation).
+
+## Basic Structure
+
+The MLLM format uses `messages` (with `role`/`content`) and `images` fields. This is the format output by the conversion script and expected by MindSpeed-MM training.
+
+```json
+[
+    {
+        "images": ["path/to/image.jpg"],
+        "messages": [
+            {
+                "role": "user",
+                "content": "<image>\nDescribe the contents of this image."
+            },
+            {
+                "role": "assistant",
+                "content": "This image shows a cat sitting on a sofa."
+            }
+        ]
+    }
+]
+```
+
+> **Important**: The field names (`messages`, `images`, `role`, `content`) must match the `attr` section in `data.json`. The default `data_3b.json` maps `"messages": "messages"` and `"images": "images"`. Using different field names (e.g., `conversations` instead of `messages`) will cause `KeyError` at runtime.
+
+## Field Descriptions
+
+### Top-Level Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `images` | array[string] | Conditional | List of image file paths (relative to `dataset_dir`) |
+| `messages` | array | Yes | List of conversation turns |
+| `videos` | array[string] | Conditional | List of video file paths (if the model supports video input) |
+
+> At least one of `images` or `videos` should be present (plain text conversations may omit both, but VLM training typically requires visual input).
+
+### messages Field
+
+Each conversation turn contains:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `role` | string | Yes | Role identifier: `"user"` or `"assistant"` |
+| `content` | string | Yes | Conversation content |
+
+#### Special Tokens
+
+| Token | Description |
+|-------|-------------|
+| `<image>` | Image placeholder; marks the image insertion position within `content` |
+| `<video>` | Video placeholder (if applicable) |
+
+> The number of `<image>` tokens must match the length of the `images` array. In multi-image scenarios, each `<image>` corresponds in order to the paths in the `images` array.
+
+## Examples
+
+### Single Image, Single-Turn Conversation
+
+```json
+{
+    "images": ["COCO2017/train2017/000000000009.jpg"],
+    "messages": [
+        {
+            "role": "user",
+            "content": "<image>\nWhat is in this image?"
+        },
+        {
+            "role": "assistant",
+            "content": "The image shows a golden Labrador Retriever running on a grassy field. The background features a blue sky with white clouds."
+        }
+    ]
+}
+```
+
+### Single Image, Multi-Turn Conversation
+
+```json
+{
+    "images": ["COCO2017/train2017/000000000025.jpg"],
+    "messages": [
+        {
+            "role": "user",
+            "content": "<image>\nPlease describe this image."
+        },
+        {
+            "role": "assistant",
+            "content": "This is an indoor photo showing a modern-style living room."
+        },
+        {
+            "role": "user",
+            "content": "How many chairs are in the living room?"
+        },
+        {
+            "role": "assistant",
+            "content": "There are two chairs in the living room: a gray armchair and a white dining chair."
+        }
+    ]
+}
+```
+
+### Multi-Image Conversation
+
+```json
+{
+    "images": [
+        "COCO2017/train2017/000000000030.jpg",
+        "COCO2017/train2017/000000000036.jpg"
+    ],
+    "messages": [
+        {
+            "role": "user",
+            "content": "<image>\n<image>\nPlease compare the similarities and differences between these two images."
+        },
+        {
+            "role": "assistant",
+            "content": "The first image is a daytime city street scene, and the second is a nighttime view of the same location. Both images show the same street, but the lighting and atmosphere are completely different."
+        }
+    ]
+}
+```
+
+### Plain Text Conversation (No Images)
+
+```json
+{
+    "messages": [
+        {
+            "role": "user",
+            "content": "Please explain what a convolutional neural network is."
+        },
+        {
+            "role": "assistant",
+            "content": "A convolutional neural network (CNN) is a type of deep learning model..."
+        }
+    ]
+}
+```
+
+## Image Path Resolution
+
+The image path concatenation rule:
+
+```
+Final path = dataset_dir from data.json + image path from MLLM JSON
+```
+
+Example:
+- `dataset_dir`: `"./data"`
+- `image`: `["COCO2017/train2017/000000000009.jpg"]`
+- Final path: `./data/COCO2017/train2017/000000000009.jpg`
+
+## Converting from LLaVA Format
+
+The conversion script transforms LLaVA-Instruct-150K format into MLLM format:
+
+| Field | LLaVA Format | MLLM Format |
+|-------|-------------|-------------|
+| Image | `"image": "000000033471.jpg"` (string) | `"images": ["./data/COCO2017/train2017/000000033471.jpg"]` (array with full path) |
+| Conversations | `"conversations": [{"from": "human", "value": ...}]` | `"messages": [{"role": "user", "content": ...}]` |
+| Role names | `"human"` / `"gpt"` | `"user"` / `"assistant"` |
+
+Conversion script:
+
+```bash
+# Must run from MindSpeed-MM root — script uses hardcoded ./data/ paths
+cd /root/workspace/MindSpeed-MM
+python examples/qwen2vl/llava_instruct_2_mllm_demo_format.py
+```
+
+> **Note**: The script reads from `./data/llava_instruct_150k.json` and checks image existence under `./data/COCO2017/train2017/`. Ensure data is at these paths or create symlinks before running.
+
+## Custom Dataset Preparation
+
+If using your own dataset, follow these steps:
+
+1. **Organize image files**: Place them in a unified directory and ensure paths are accessible
+2. **Write annotation JSON**: Create conversation annotations in MLLM format
+3. **Validate format**: Ensure the number of `<image>` tokens matches the length of the `images` array
+4. **Configure data.json**: Set the correct `dataset_dir` and `dataset` paths
+
+### Format Validation Checklist
+
+- [ ] JSON syntax is valid (verify with `python -m json.tool`)
+- [ ] Field names match `attr` config: `messages` (not `conversations`), `images` (not `image`)
+- [ ] Each turn in `messages` uses `role`/`content` (not `from`/`value`)
+- [ ] The `messages` array alternates between `user`/`assistant` turns
+- [ ] For samples containing images, the number of `<image>` tokens matches the `images` array length
+- [ ] Image paths are correctly accessible relative to `dataset_dir`
+- [ ] Image files are in JPEG or PNG format

--- a/mindspeed-mm/mindspeed-mm-vlm/references/model-delta-cards.md
+++ b/mindspeed-mm/mindspeed-mm-vlm/references/model-delta-cards.md
@@ -1,0 +1,195 @@
+# VLM Model Delta Cards
+
+Delta reference vs. the Qwen2.5VL baseline flow (Megatron backend, JSON configs, `pretrain_vlm.py`, `mm-convert hf_to_mm`).
+
+---
+
+### Qwen3VL
+
+| Item | Value |
+|---|---|
+| Dir | `examples/qwen3vl/` |
+| Backend | FSDP2 (`--use-torch-fsdp2`, `fsdp2_config.yaml`) |
+| Entry script | `pretrain_transformers.py` (not `pretrain_vlm.py`) |
+| Config format | YAML (`qwen3vl_full_sft_xxB.yaml`) -- single file replaces model.json + data.json |
+| Weight conversion | `mm-convert Qwen3VLConverter hf_to_dcp` (DCP format, not hf_to_mm) |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=2` (must not be 1 with FSDP2) |
+| Extra deps | `pip install -e git+...transformers.git@c0dbe09` (git-installed, not pip release) |
+
+**Key differences from Qwen2.5VL**:
+- FSDP2 replaces Megatron TP/PP; all parallel config lives in `fsdp2_config.yaml`
+- YAML config is the single source of truth (no separate model.json / data.json)
+- Weight format is DCP (Distributed Checkpoint), converter is `Qwen3VLConverter hf_to_dcp`
+- Reverse conversion: `Qwen3VLConverter dcp_to_hf` (for inference after training)
+- Meta-init (`init_model_with_meta_device: true`) mandatory for 30B/235B; loads DCP weights at `MM_MODEL_LOAD_PATH`
+- MoE models (30B/235B): optional `use_npu_fused_moe`, expert parallel via `fsdp2_config.yaml`
+- Requires git-installed transformers (commit `c0dbe09`), not a pip-released version
+
+**Quick start**:
+```bash
+bash scripts/install.sh --megatron --msid 96bc0a3bf3 && pip install -r examples/qwen3vl/requirements.txt
+mm-convert Qwen3VLConverter hf_to_dcp --hf_dir Qwen3-VL-8B --dcp_dir Qwen3-VL-8B-dcp
+# edit qwen3vl_full_sft_8B.yaml paths
+bash examples/qwen3vl/finetune_qwen3vl_8B.sh
+```
+
+---
+
+### InternVL3.5
+
+| Item | Value |
+|---|---|
+| Dir | `examples/internvl3.5/` |
+| Backend | FSDP2 (`--use-torch-fsdp2`, `fsdp2_config.yaml`) |
+| Entry script | `pretrain_transformers.py` |
+| Config format | JSON (`data.json` + `model.json`) |
+| Weight conversion | `mm-convert ExpertMergeDcpConverter hf_to_dcp` (MoE expert-merge converter) |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=2` |
+| Extra deps | git-installed transformers (`c0dbe09`); creates symlink `ln -s $HF_PATH ./internvl` |
+
+**Key differences from Qwen2.5VL**:
+- MoE model (30B-A3B) uses `ExpertMergeDcpConverter` -- merges expert weights into DCP format
+- Must patch HF code: edit `modeling_internvl_chat.py` line 96 (`img_context_token_id = 151671`) and line 112 (add `**kwargs` to forward)
+- Meta-init enabled by default (`--init-model-with-meta-device`)
+- Shell script creates a symlink `./internvl -> $HF_PATH` before training
+- Reverse conversion: `ExpertMergeDcpConverter dcp_to_hf`
+- Default 16 NPUs per node (A3 machine); single machine requires 16 cards
+
+**Quick start**:
+```bash
+# install MindSpeed + transformers from git
+mm-convert ExpertMergeDcpConverter hf_to_dcp --hf_dir ckpt/hf_path/InternVL3_5-30B-A3B-Instruct --save_dir ckpt/convert_path/InternVL3_5-30B-A3B-Instruct
+# patch modeling_internvl_chat.py (line 96 + 112)
+# edit data.json, model.json paths
+bash examples/internvl3.5/finetune_internvl3_5.sh
+```
+
+---
+
+### GLM-4.5V
+
+| Item | Value |
+|---|---|
+| Dir | `examples/glm4.5v/` |
+| Backend | FSDP2 (`--use-torch-fsdp2`, `fsdp2_config.yaml`) |
+| Entry script | `pretrain_transformers.py` |
+| Config format | JSON (`data_106B.json` + `model_106B.json`) |
+| Weight conversion | `mm-convert ExpertMergeDcpConverter hf_to_dcp` |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=2` |
+| Extra deps | git-installed transformers (`8cb5963` -- different commit from Qwen3VL!) |
+
+**Key differences from Qwen2.5VL**:
+- 106B MoE model; meta-init mandatory (`--init-model-with-meta-device`)
+- Uses `ExpertMergeDcpConverter` (same as InternVL3.5)
+- LOAD_PATH must point to converted weights at `ckpt/mm_path/GLM-4.5V` (not original HF path)
+- Default multi-machine: 8 nodes x 16 NPUs (128 cards); single-machine only for reduced-layer debug
+- MoE fused ops enabled via `use_npu_fused_moe: true` in `model_106B.json`
+- transformers commit `8cb5963` differs from other FSDP2 models
+
+**Quick start**:
+```bash
+# install MindSpeed + transformers@8cb5963
+mm-convert ExpertMergeDcpConverter hf_to_dcp --hf_dir "ckpt/hf_path/GLM-4.5V" --save_dir "ckpt/mm_path/GLM-4.5V"
+# edit data_106B.json, model_106B.json paths
+bash examples/glm4.5v/finetune_glm4_5v_106B.sh
+```
+
+---
+
+### DeepSeekVL2
+
+| Item | Value |
+|---|---|
+| Dir | `examples/deepseekvl2/` |
+| Backend | Megatron (TP/PP/EP, not FSDP2) |
+| Entry script | `pretrain_deepseekvl.py` (custom, not `pretrain_vlm.py`) |
+| Config format | JSON (`data.json` + `model.json`) |
+| Weight conversion | `mm-convert DeepSeekVLConverter hf_to_mm` (classic format, supports TP/EP slicing) |
+| Key env vars | `CUDA_DEVICE_MAX_CONNECTIONS=1` (standard Megatron) |
+| Extra deps | `deepseekvl2` package from upstream repo; transformers 4.45.0 or 4.38.2 |
+
+**Key differences from Qwen2.5VL**:
+- Custom entry script `pretrain_deepseekvl.py` with MLA (Multi-head Latent Attention) and MoE args
+- Converter is `DeepSeekVLConverter hf_to_mm` with explicit `--cfg.parallel_config` for PP/EP/TP slicing
+- Must edit `config.json` field `_attn_implementation` to `"eager"` before conversion
+- Custom dataset type: `dataset_type: "deepseekvl2"` (not `huggingface`)
+- Uses MLA args: `--multi-head-latent-attention`, `--qk-rope-head-dim 64`, `--kv-lora-rank 512`, etc.
+- Uses MoE args: `--moe-permutation-async-comm`, `--moe-token-dispatcher-type alltoall`
+- Default 4 nodes x 8 NPUs with PP=2, EP=8
+- No reverse converter documented (no dcp_to_hf / mm_to_hf in README)
+
+**Quick start**:
+```bash
+pip install deepseekvl2  # from upstream repo
+# edit raw_ckpt/DeepSeekVL2/config.json: _attn_implementation -> "eager"
+mm-convert DeepSeekVLConverter hf_to_mm --cfg.hf_config.hf_dir raw_ckpt/DeepSeekVL2 --cfg.mm_dir pretrained/DeepSeekVL2 --cfg.parallel_config.ep_size 8 --cfg.parallel_config.tp_size 1 --cfg.parallel_config.llm_pp_layers '[[13,17]]' --cfg.parallel_config.vit_pp_layers '[[27,0]]' --cfg.trust_remote_code True
+# edit data.json, model.json paths
+bash examples/deepseekvl2/finetune_deepseekvl2.sh
+```
+
+---
+
+### DeepSeekOCR
+
+| Item | Value |
+|---|---|
+| Dir | `examples/deepseekocr/` |
+| Backend | Native PyTorch (no Megatron, no FSDP2) |
+| Entry script | `examples/deepseekocr/finetune_ocr.py` (completely custom trainer) |
+| Config format | CLI args only (no JSON/YAML config files) |
+| Weight conversion | None -- loads HF weights directly |
+| Key env vars | (minimal: `OMP_NUM_THREADS=1`) |
+| Extra deps | `transformers==4.46.3` (DOWNGRADE!), `tokenizers==0.20.3`, `PyMuPDF`, `img2pdf` |
+
+**Key differences from Qwen2.5VL**:
+- Completely custom training loop in `finetune_ocr.py` -- not based on Megatron or FSDP2
+- No `mm-convert` step; loads HF weights directly via `--load`
+- No model.json / data.json / YAML; all config passed as CLI args to `finetune_ocr.py`
+- Requires `transformers==4.46.3` -- explicit downgrade from latest, will conflict with other models
+- Custom dataset class in `ocr_dataset.py` with its own format converter `convert_ccocr_to_dsvlocr.py`
+- Data format: JSONL with `role: "<|User|>"` / `role: "<|Assistant|>"` (DeepSeek chat format, not ShareGPT)
+- Strongly recommended: use a separate conda environment
+
+**Quick start**:
+```bash
+conda create -n deepseekocr python=3.10 && conda activate deepseekocr
+pip install -r examples/deepseekocr/requirements.txt
+python examples/deepseekocr/convert_ccocr_to_dsvlocr.py
+# edit finetune_ocr.sh: DATA_PATH, DATA_DIR, LOAD_PATH
+bash examples/deepseekocr/finetune_ocr.sh
+```
+
+---
+
+### Ming-Lite-Omni v1.5
+
+| Item | Value |
+|---|---|
+| Dir | `examples/ming/` (but runs from cloned Ming repo, not MindSpeed-MM) |
+| Backend | Native PyTorch FSDP (not Megatron, not FSDP2) |
+| Entry script | `finetune_vl.py` (custom trainer, runs from Ming repo root) |
+| Config format | CLI args only (no JSON/YAML config files) |
+| Weight conversion | None -- loads HF weights directly |
+| Key env vars | (minimal: `OMP_NUM_THREADS=1`) |
+| Extra deps | Heavy: `diffusers==0.33.1`, `funasr==1.1.14`, `openai-whisper==20240930`, `torchaudio`, `peft`, `modelscope`, `onnxruntime` |
+
+**Key differences from Qwen2.5VL**:
+- Runs from the upstream Ming repo, not MindSpeed-MM: `git clone Ming && cp -r MindSpeed-MM/examples/ming/* ./`
+- Custom training loop in `finetune_vl.py` -- no Megatron, no FSDP2
+- No `mm-convert` step; loads HF weights directly via `--load`
+- No model.json / data.json / YAML; all config passed as CLI args
+- Massive dependency footprint: whisper, funasr, diffusers, torchaudio (omni-modal model)
+- `transformers==4.45.0` -- different version from most other models
+- Data format uses `messages` with `role: "user"/"assistant"` (OpenAI format, not ShareGPT)
+- PROCESSOR_PATH points to Ming repo root (needs Ming's custom processor code)
+- Strongly recommended: use a separate conda environment
+
+**Quick start**:
+```bash
+conda create -n ming python=3.10 && conda activate ming
+git clone https://github.com/inclusionAI/Ming.git && cd Ming && git checkout d97e2f3
+cp -r ../MindSpeed-MM/examples/ming/* ./
+pip install -r MindSpeed-MM/examples/ming/requirements.txt
+# edit finetune_vl.sh: DATA_PATH, DATA_DIR, PROCESSOR_PATH, LOAD_PATH
+bash finetune_vl.sh   # run from Ming/ dir, not MindSpeed-MM/
+```

--- a/mindspeed-mm/mindspeed-mm-vlm/references/per-model-deps.md
+++ b/mindspeed-mm/mindspeed-mm-vlm/references/per-model-deps.md
@@ -1,0 +1,148 @@
+# VLM Model Dependency Configuration
+
+This document lists the dependency requirements and installation methods for each VLM model supported by MindSpeed-MM.
+
+## Dependency Conflict Overview
+
+The primary conflict between VLM models lies in the `transformers` library version:
+
+| Model | transformers Version | Conflict Risk |
+|-------|---------------------|---------------|
+| Qwen2.5VL | >= 4.45.0 | Low |
+| Qwen3VL | Latest development version (bleeding-edge) | High; may break other models |
+| InternVL2.5/3 | >= 4.44.0 | Low |
+| GLM4.1V | >= 4.44.0 | Low |
+| DeepSeekVL2 | >= 4.44.0 | Low |
+| DeepSeekOCR | == 4.46.3 (downgrade) | High; conflicts with Qwen3VL |
+
+> **Conclusion**: Qwen3VL and DeepSeekOCR must use separate environments and cannot be installed together.
+
+## Per-Model Dependency Details
+
+### Qwen2.5VL
+
+**Additional dependencies**: None. The MindSpeed-MM base environment is sufficient.
+
+```bash
+# No additional installation required
+# The base environment already includes all needed dependencies
+```
+
+Base environment requirements:
+- torch >= 2.1
+- torch_npu (matching the CANN version)
+- transformers >= 4.45.0
+- accelerate
+- Pillow
+
+### Qwen3VL
+
+**Additional dependencies**: Requires bleeding-edge transformers.
+
+```bash
+pip install -r examples/qwen3vl/requirements.txt
+```
+
+Key dependency changes:
+- transformers: Install the latest development version (may require git+https installation)
+- May require updating related libraries such as tokenizers and safetensors
+
+> **Warning**: Installation will overwrite the system transformers version, affecting models like Qwen2.5VL. Using a separate container is recommended.
+
+### InternVL2.5 / InternVL3
+
+**Additional dependencies**: None. The MindSpeed-MM base environment is sufficient.
+
+```bash
+# No additional installation required
+# The actual directory is examples/internvl3/ (not examples/internvl/) and it has no requirements.txt
+```
+
+Key notes:
+- transformers >= 4.44.0 (already satisfied by the base environment)
+- timm and einops may be needed depending on usage, but are not listed in a requirements.txt
+
+### GLM4.1V
+
+**Additional dependencies**:
+
+```bash
+pip install -r examples/glm4v/requirements.txt
+```
+
+Generally compatible with the base environment; low conflict risk.
+
+### DeepSeekVL2
+
+**Additional dependencies**: None. The MindSpeed-MM base environment is sufficient.
+
+```bash
+# No additional installation required
+# The actual directory is examples/deepseekvl2/ (not examples/deepseekvl/) and it has no requirements.txt
+```
+
+Note MoE-related dependencies. Generally compatible with the base environment.
+
+### DeepSeekOCR
+
+**Additional dependencies**:
+
+```bash
+pip install -r examples/deepseekocr/requirements.txt
+```
+
+Key changes:
+- **transformers is downgraded to 4.46.3**
+- This is a significant downgrade from the base 4.57.0 with different API/behavior, and will break Qwen2.5VL and Qwen3VL
+
+> **Strongly recommended**: Use a separate Docker container for DeepSeekOCR-related tasks.
+
+## Environment Isolation Strategies
+
+### Option 1: Separate Docker Containers (Recommended)
+
+Create a separate container for each model with conflicting dependencies:
+
+```bash
+# Qwen2.5VL / InternVL / GLM4V / DeepSeekVL2 share the base container
+docker run -it --name mm-vlm-base ...
+
+# Qwen3VL in a separate container
+docker run -it --name mm-vlm-qwen3vl ...
+pip install -r examples/qwen3vl/requirements.txt
+
+# DeepSeekOCR in a separate container
+docker run -it --name mm-vlm-deepseekocr ...
+pip install -r examples/deepseekocr/requirements.txt
+```
+
+### Option 2: Conda Environments
+
+```bash
+# Base environment
+conda create -n mm-vlm-base python=3.10
+conda activate mm-vlm-base
+# ... install base dependencies
+
+# Qwen3VL environment
+conda create -n mm-vlm-qwen3vl python=3.10
+conda activate mm-vlm-qwen3vl
+pip install -r examples/qwen3vl/requirements.txt
+
+# DeepSeekOCR environment
+conda create -n mm-vlm-deepseekocr python=3.10
+conda activate mm-vlm-deepseekocr
+pip install -r examples/deepseekocr/requirements.txt
+```
+
+## Compatibility Matrix
+
+| Environment | Qwen2.5VL | Qwen3VL | InternVL | GLM4V | DeepSeekVL2 | DeepSeekOCR |
+|-------------|-----------|---------|----------|-------|-------------|-------------|
+| Base environment | OK | X | OK | OK | OK | X |
+| Qwen3VL environment | Needs verification | OK | Needs verification | Needs verification | Needs verification | X |
+| DeepSeekOCR environment | X | X | X | X | X | OK |
+
+- **OK**: Verified to work correctly
+- **X**: Incompatible or not verified
+- **Needs verification**: Theoretically possible, but requires actual testing to confirm

--- a/mindspeed-mm/mindspeed-mm-weight-prep/SKILL.md
+++ b/mindspeed-mm/mindspeed-mm-weight-prep/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: mindspeed-mm-weight-prep
+description: "MindSpeed-MM weight conversion guide using mm-convert CLI tool. Covers HuggingFace to MindSpeed-MM format conversion, reverse conversion, and PP weight resplitting. Supports Qwen2VLConverter, Qwen2_5_VLConverter, InternVLConverter, WanConverter and more. Use when converting multimodal model weights on Ascend NPU."
+keywords:
+    - mindspeed-mm
+    - weight
+    - weight conversion
+    - mm-convert
+    - hf_to_mm
+    - mm_to_hf
+    - checkpoint
+    - converter
+---
+
+# MindSpeed-MM Weight Conversion
+
+This Skill guides users through converting multimodal model weights between HuggingFace and MindSpeed-MM formats using the `mm-convert` CLI tool, including VLM (Vision-Language Models) and generative models (video generation, etc.).
+
+## mm-convert CLI Overview
+
+```bash
+mm-convert -h
+# Available subcommands: Qwen2VLConverter, Qwen2_5_VLConverter, InternVLConverter, WanConverter, ...
+```
+
+Converters support different operations depending on the model. Common operations include:
+
+| Operation | Description |
+|-----------|-------------|
+| `hf_to_mm` | HuggingFace weights -> MindSpeed-MM format (Megatron models) |
+| `mm_to_hf` | MindSpeed-MM weights -> HuggingFace format (export after training) |
+| `hf_to_dcp` / `dcp_to_hf` | DCP format conversion (FSDP2 models, e.g., Qwen3VL, InternVL3.5) |
+| `source_to_mm` | Source weights -> MM format (e.g., OpenSoraPlan v1.5) |
+| `resplit` | PP weight resplitting (adjust parallelism strategy without re-converting) |
+
+> **Note**: Not all converters support all operations. Check the [Model Registry](../mindspeed-mm-pipeline/references/model-registry.md) for the exact operations supported by each converter.
+
+## Converter Selection
+
+| Model Family | Converter Class | Key Parameters |
+|--------------|----------------|----------------|
+| Qwen2VL | `Qwen2VLConverter` | `llm_pp_layers`, `vit_pp_layers`, `tp_size` |
+| Qwen2.5VL | `Qwen2_5_VLConverter` | `llm_pp_layers`, `vit_pp_layers`, `tp_size` |
+| InternVL2.5, InternVL3 | `InternVLConverter` | `llm_pp_layers`, `vit_pp_layers`, `tp_size` |
+| Wan2.1, Wan2.2 | `WanConverter` | `source_path`, `target_path`, `target_parallel_config.pp_layers` |
+
+> **Selection rule**: Match the Converter directly based on the model name. Qwen2VL and Qwen2.5VL use different Converters and must not be mixed.
+
+## Quick Start
+
+### VLM: HuggingFace -> MindSpeed-MM
+
+Using Qwen2.5-VL-3B-Instruct as an example (single device, no PP splitting):
+
+```bash
+mm-convert Qwen2_5_VLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [[36]] \
+  --cfg.parallel_config.vit_pp_layers [[32]] \
+  --cfg.parallel_config.tp_size 1
+```
+
+### VLM: MindSpeed-MM -> HuggingFace
+
+```bash
+mm-convert Qwen2_5_VLConverter mm_to_hf \
+  --cfg.save_hf_dir "ckpt/mm_to_hf/Qwen2.5-VL-3B-Instruct" \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-3B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [36] \
+  --cfg.parallel_config.vit_pp_layers [32] \
+  --cfg.parallel_config.tp_size 1
+```
+
+> **Note**: For `mm_to_hf`, `llm_pp_layers` and `vit_pp_layers` use a 1D list (e.g., `[36]`), not a nested list. `--cfg.hf_config.hf_dir` must point to the original HF weights directory (containing config.json).
+
+### Generative Model: Wan2.1 hf_to_mm
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/
+```
+
+### Generative Model: Wan mm_to_hf
+
+```bash
+mm-convert WanConverter mm_to_hf \
+  --cfg.source_path <saved_weight_path>/ \
+  --cfg.target_path ./converted_weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.hf_dir <original_hf_weights>/transformer/
+```
+
+> WanConverter uses a different parameter system from VLM Converters: it uses `source_path` / `target_path` instead of `mm_dir` / `hf_config.hf_dir`.
+
+## Parameter Passing Methods
+
+`mm-convert` is based on jsonargparse and supports three parameter passing methods:
+
+### 1. Command-line Arguments
+
+Pass parameters directly on the command line with `--cfg.xxx` (as shown in the examples above).
+
+### 2. YAML Configuration File
+
+First generate an annotated template, then modify as needed:
+
+```bash
+# Generate configuration template
+mm-convert Qwen2_5_VLConverter hf_to_mm --print_config=comments > config.yaml
+
+# Use configuration file
+mm-convert Qwen2_5_VLConverter hf_to_mm --config config.yaml
+```
+
+Configuration file example:
+
+```yaml
+cfg:
+  mm_dir: "ckpt/mm_path/Qwen2.5-VL-3B-Instruct"
+  hf_config:
+    hf_dir: "ckpt/hf_path/Qwen2.5-VL-3B-Instruct"
+  parallel_config:
+    llm_pp_layers: [[36]]
+    vit_pp_layers: [[32]]
+    tp_size: 1
+```
+
+### 3. Environment Variables
+
+```bash
+export JSONARGPARSE_DEFAULT_ENV=true
+# Then set parameters via environment variables (refer to jsonargparse documentation for variable naming conventions)
+```
+
+## PP Splitting Guide
+
+### PP Splitting for VLM Models
+
+VLM models have two components that need splitting: LLM and ViT.
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `llm_pp_layers` | Number of layers per PP stage for LLM | `[[1,10,10,7]]` means 4 stages |
+| `vit_pp_layers` | Number of layers per PP stage for ViT | `[[32,0,0,0]]` means all ViT in stage 0 |
+| `tp_size` | Tensor parallelism degree | Must match the TP value in the training script |
+
+**Splitting Rules**:
+
+- Sum of elements in `llm_pp_layers` = total number of LLM layers
+- Sum of elements in `vit_pp_layers` = total number of ViT layers
+- Both lists must have the same length (= number of PP stages)
+- Must be consistent with the `pipeline_num_layers` configuration in `model.json`
+- ViT layers are typically concentrated in stage 0 (e.g., `[[32,0,0,0]]`), but can also be distributed
+
+**Example: 4-device PP (Qwen2.5-VL-7B, 28-layer LLM + 32-layer ViT)**:
+
+```bash
+--cfg.parallel_config.llm_pp_layers [[1,10,10,7]] \
+--cfg.parallel_config.vit_pp_layers [[32,0,0,0]]
+```
+
+### PP Splitting for Wan Models
+
+Wan models use the `target_parallel_config.pp_layers` parameter:
+
+```bash
+--cfg.target_parallel_config.pp_layers [[6,6,6,6]]  # 24-layer model, evenly split across 4 stages
+```
+
+### resplit: PP Weight Resplitting
+
+When already-converted MM weights need a different PP strategy, use `resplit` instead of re-converting from HF:
+
+```bash
+mm-convert Qwen2_5_VLConverter resplit \
+  --cfg.source_dir "ckpt/mm_path/old_pp/" \
+  --cfg.target_dir "ckpt/mm_path/new_pp/" \
+  --cfg.source_parallel_config.llm_pp_layers [[28]] \
+  --cfg.source_parallel_config.vit_pp_layers [[32]] \
+  --cfg.target_parallel_config.llm_pp_layers [[1,10,10,7]] \
+  --cfg.target_parallel_config.vit_pp_layers [[32,0,0,0]] \
+  --cfg.target_parallel_config.tp_size 1
+```
+
+## FAQ
+
+**Q: Conversion fails due to transformers version mismatch**
+
+Error messages like `KeyError` or weight key mismatches. This is caused by the local transformers version not matching the version corresponding to the model weights. Solution: re-download the latest weights from HuggingFace, or install a matching transformers version.
+
+**Q: Weights saved from LayerZero training cannot be directly converted with mm_to_hf**
+
+Weights saved from LayerZero training have a different format from the standard MM format. They need post-processing (merging or reordering) before running `mm_to_hf` conversion.
+
+**Q: hf_to_mm and mm_to_hf use different pp_layers formats**
+
+`hf_to_mm` uses nested lists `[[36]]`, while `mm_to_hf` uses 1D lists `[36]`. Be careful to distinguish between them.
+
+**Q: Loading fails due to tp_size mismatch**
+
+The `tp_size` during conversion must exactly match the TP value in the training script. If training uses TP=2, conversion must also set `tp_size 2`.
+
+**Q: llm and vit PP layer list lengths are inconsistent**
+
+`llm_pp_layers` and `vit_pp_layers` must have the same number of elements (i.e., the same number of PP stages).
+
+## Usage Order
+
+After weight conversion is complete:
+
+1. **Start training** -> Refer to the MindSpeed-MM Training Skill
+
+## References
+
+- [Detailed Conversion Guide](references/conversion-guide.md) - Complete parameter tables for each Converter, multi-model multi-scale examples
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)

--- a/mindspeed-mm/mindspeed-mm-weight-prep/references/conversion-guide.md
+++ b/mindspeed-mm/mindspeed-mm-weight-prep/references/conversion-guide.md
@@ -1,0 +1,367 @@
+# MindSpeed-MM Weight Conversion Detailed Guide
+
+## Converter Overview
+
+| Converter | Applicable Models | Supported Operations |
+|-----------|-------------------|----------------------|
+| `Qwen2VLConverter` | Qwen2-VL series | hf_to_mm, mm_to_hf, resplit |
+| `Qwen2_5_VLConverter` | Qwen2.5-VL series | hf_to_mm, mm_to_hf, resplit |
+| `InternVLConverter` | InternVL2.5, InternVL3 series | hf_to_mm, mm_to_hf, resplit |
+| `WanConverter` | Wan2.1, Wan2.2 series | hf_to_mm, mm_to_hf, resplit |
+
+## Qwen2_5_VLConverter Full Parameters
+
+### hf_to_mm Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.mm_dir` | MindSpeed-MM format output path | Yes |
+| `--cfg.hf_config.hf_dir` | HuggingFace source weights path | Yes |
+| `--cfg.parallel_config.llm_pp_layers` | LLM PP splitting (nested list) | Yes |
+| `--cfg.parallel_config.vit_pp_layers` | ViT PP splitting (nested list) | Yes |
+| `--cfg.parallel_config.tp_size` | Tensor parallelism degree | Yes |
+
+### mm_to_hf Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.save_hf_dir` | HuggingFace format output path | Yes |
+| `--cfg.mm_dir` | MindSpeed-MM source weights path | Yes |
+| `--cfg.hf_config.hf_dir` | Original HF weights path (with config.json) | Yes |
+| `--cfg.parallel_config.llm_pp_layers` | LLM PP splitting (1D list) | Yes |
+| `--cfg.parallel_config.vit_pp_layers` | ViT PP splitting (1D list) | Yes |
+| `--cfg.parallel_config.tp_size` | Tensor parallelism degree | Yes |
+
+### resplit Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.source_dir` | Source MM weights path | Yes |
+| `--cfg.target_dir` | Target MM weights path | Yes |
+| `--cfg.source_parallel_config.llm_pp_layers` | Source LLM PP splitting | Yes |
+| `--cfg.source_parallel_config.vit_pp_layers` | Source ViT PP splitting | Yes |
+| `--cfg.target_parallel_config.llm_pp_layers` | Target LLM PP splitting | Yes |
+| `--cfg.target_parallel_config.vit_pp_layers` | Target ViT PP splitting | Yes |
+| `--cfg.target_parallel_config.tp_size` | Target tensor parallelism degree | Yes |
+
+## InternVLConverter Full Parameters
+
+### hf_to_mm Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.mm_dir` | MindSpeed-MM format output path | Yes |
+| `--cfg.hf_config.hf_dir` | HuggingFace source weights path | Yes |
+| `--cfg.parallel_config.llm_pp_layers` | LLM PP splitting (nested list) | Yes |
+| `--cfg.parallel_config.vit_pp_layers` | ViT PP splitting (nested list) | Yes |
+| `--cfg.parallel_config.tp_size` | Tensor parallelism degree | Yes |
+
+### mm_to_hf Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.save_hf_dir` | HuggingFace format output path | Yes |
+| `--cfg.mm_dir` | MindSpeed-MM source weights path | Yes |
+| `--cfg.hf_config.hf_dir` | Original HF weights path (with config.json) | Yes |
+| `--cfg.parallel_config.llm_pp_layers` | LLM PP splitting (1D list) | Yes |
+| `--cfg.parallel_config.vit_pp_layers` | ViT PP splitting (1D list) | Yes |
+| `--cfg.parallel_config.tp_size` | Tensor parallelism degree | Yes |
+
+## WanConverter Full Parameters
+
+### hf_to_mm Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.source_path` | HuggingFace source weights path (transformer subdirectory) | Yes |
+| `--cfg.target_path` | MindSpeed-MM format output path | Yes |
+| `--cfg.target_parallel_config.pp_layers` | PP splitting (nested list, optional) | No |
+
+### mm_to_hf Parameters
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `--cfg.source_path` | MindSpeed-MM source weights path | Yes |
+| `--cfg.target_path` | HuggingFace format output path | Yes |
+| `--cfg.hf_dir` | Original HF weights path (used for structure reference) | Yes |
+
+> WanConverter parameter naming differs significantly from VLM Converters: it uses `source_path`/`target_path` instead of `mm_dir`/`hf_config.hf_dir`, and has no `parallel_config` nesting.
+
+## Multi-Model Conversion Examples
+
+### Qwen2.5-VL-7B-Instruct (PP=4, TP=1)
+
+**hf_to_mm**:
+
+```bash
+mm-convert Qwen2_5_VLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-7B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-7B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [[1,10,10,7]] \
+  --cfg.parallel_config.vit_pp_layers [[32,0,0,0]] \
+  --cfg.parallel_config.tp_size 1
+```
+
+- Qwen2.5-VL-7B LLM has 28 layers total, distributed as 1+10+10+7 across 4 PP stages
+- ViT has 32 layers total, all placed in stage 0
+
+**mm_to_hf**:
+
+```bash
+mm-convert Qwen2_5_VLConverter mm_to_hf \
+  --cfg.save_hf_dir "ckpt/mm_to_hf/Qwen2.5-VL-7B-Instruct" \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-7B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-7B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [1,10,10,7] \
+  --cfg.parallel_config.vit_pp_layers [32,0,0,0] \
+  --cfg.parallel_config.tp_size 1
+```
+
+### Qwen2.5-VL-72B-Instruct (PP=4, TP=4)
+
+**hf_to_mm**:
+
+```bash
+mm-convert Qwen2_5_VLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-72B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-72B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [[1,26,26,27]] \
+  --cfg.parallel_config.vit_pp_layers [[32,0,0,0]] \
+  --cfg.parallel_config.tp_size 4
+```
+
+- Qwen2.5-VL-72B LLM has 80 layers total, distributed as 1+26+26+27 across 4 PP stages
+- ViT has 32 layers total, all in stage 0
+- TP=4 means at least 4*4=16 NPUs are required
+
+**mm_to_hf**:
+
+```bash
+mm-convert Qwen2_5_VLConverter mm_to_hf \
+  --cfg.save_hf_dir "ckpt/mm_to_hf/Qwen2.5-VL-72B-Instruct" \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2.5-VL-72B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2.5-VL-72B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [1,26,26,27] \
+  --cfg.parallel_config.vit_pp_layers [32,0,0,0] \
+  --cfg.parallel_config.tp_size 4
+```
+
+### Qwen2-VL-7B-Instruct (PP=2, TP=2)
+
+**hf_to_mm** (note: use `Qwen2VLConverter`, not `Qwen2_5_VLConverter`):
+
+```bash
+mm-convert Qwen2VLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/Qwen2-VL-7B-Instruct" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/Qwen2-VL-7B-Instruct" \
+  --cfg.parallel_config.llm_pp_layers [[14,14]] \
+  --cfg.parallel_config.vit_pp_layers [[32,0]] \
+  --cfg.parallel_config.tp_size 2
+```
+
+### InternVL3-78B (PP=4, TP=2)
+
+**hf_to_mm**:
+
+```bash
+mm-convert InternVLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/InternVL3-78B" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/InternVL3-78B" \
+  --cfg.parallel_config.llm_pp_layers [[1,26,26,27]] \
+  --cfg.parallel_config.vit_pp_layers [[45,0,0,0]] \
+  --cfg.parallel_config.tp_size 2
+```
+
+- InternVL3-78B LLM part is based on Qwen2.5-72B, with 80 layers total
+- InternViT has 45 layers
+- TP=2, PP=4 requires 8 NPUs
+
+**mm_to_hf**:
+
+```bash
+mm-convert InternVLConverter mm_to_hf \
+  --cfg.save_hf_dir "ckpt/mm_to_hf/InternVL3-78B" \
+  --cfg.mm_dir "ckpt/mm_path/InternVL3-78B" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/InternVL3-78B" \
+  --cfg.parallel_config.llm_pp_layers [1,26,26,27] \
+  --cfg.parallel_config.vit_pp_layers [45,0,0,0] \
+  --cfg.parallel_config.tp_size 2
+```
+
+### InternVL2.5-8B (PP=2, TP=1)
+
+**hf_to_mm**:
+
+```bash
+mm-convert InternVLConverter hf_to_mm \
+  --cfg.mm_dir "ckpt/mm_path/InternVL2_5-8B" \
+  --cfg.hf_config.hf_dir "ckpt/hf_path/InternVL2_5-8B" \
+  --cfg.parallel_config.llm_pp_layers [[16,16]] \
+  --cfg.parallel_config.vit_pp_layers [[25,0]] \
+  --cfg.parallel_config.tp_size 1
+```
+
+- InternVL2.5-8B LLM has 32 layers total, evenly split across 2 stages
+- InternViT has 25 layers
+
+### Wan2.1-T2V-1.3B (Single Device)
+
+**hf_to_mm**:
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/
+```
+
+**mm_to_hf**:
+
+```bash
+mm-convert WanConverter mm_to_hf \
+  --cfg.source_path ./training_output/Wan2.1-T2V-1.3B/ \
+  --cfg.target_path ./converted_weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/ \
+  --cfg.hf_dir ./weights/Wan-AI/Wan2.1-T2V-1.3B-Diffusers/transformer/
+```
+
+### Wan2.1-T2V-14B (PP=4)
+
+**hf_to_mm**:
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/ \
+  --cfg.target_parallel_config.pp_layers [[10,10,10,10]]
+```
+
+- Wan2.1-T2V-14B transformer has 40 layers total, evenly split across 4 PP stages
+
+**mm_to_hf**:
+
+```bash
+mm-convert WanConverter mm_to_hf \
+  --cfg.source_path ./training_output/Wan2.1-T2V-14B/ \
+  --cfg.target_path ./converted_weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/ \
+  --cfg.hf_dir ./weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/
+```
+
+### Wan2.1-I2V-14B (PP=4)
+
+**hf_to_mm**:
+
+```bash
+mm-convert WanConverter hf_to_mm \
+  --cfg.source_path ./weights/Wan-AI/Wan2.1-I2V-14B-720P-Diffusers/transformer/ \
+  --cfg.target_path ./weights/Wan-AI/Wan2.1-I2V-14B-720P-Diffusers/transformer/ \
+  --cfg.target_parallel_config.pp_layers [[10,10,10,10]]
+```
+
+## Common PP Splitting Configurations Reference
+
+### Qwen2.5-VL Series
+
+| Model | LLM Layers | ViT Layers | PP=1 | PP=2 | PP=4 |
+|-------|------------|------------|------|------|------|
+| Qwen2.5-VL-3B | 36 | 32 | `[[36]]` / `[[32]]` | `[[18,18]]` / `[[32,0]]` | `[[9,9,9,9]]` / `[[32,0,0,0]]` |
+| Qwen2.5-VL-7B | 28 | 32 | `[[28]]` / `[[32]]` | `[[14,14]]` / `[[32,0]]` | `[[1,10,10,7]]` / `[[32,0,0,0]]` |
+| Qwen2.5-VL-72B | 80 | 32 | `[[80]]` / `[[32]]` | `[[40,40]]` / `[[32,0]]` | `[[1,26,26,27]]` / `[[32,0,0,0]]` |
+
+> Table format: `llm_pp_layers` / `vit_pp_layers`
+
+### InternVL Series
+
+| Model | LLM Layers | ViT Layers | PP=2 | PP=4 |
+|-------|------------|------------|------|------|
+| InternVL2.5-8B | 32 | 25 | `[[16,16]]` / `[[25,0]]` | `[[8,8,8,8]]` / `[[25,0,0,0]]` |
+| InternVL3-78B | 80 | 45 | `[[40,40]]` / `[[45,0]]` | `[[1,26,26,27]]` / `[[45,0,0,0]]` |
+
+### Wan Series
+
+| Model | Transformer Layers | PP=1 | PP=2 | PP=4 |
+|-------|--------------------|------|------|------|
+| Wan2.1-T2V-1.3B | 24 | Not required | `[[12,12]]` | `[[6,6,6,6]]` |
+| Wan2.1-T2V-14B | 40 | Not required | `[[20,20]]` | `[[10,10,10,10]]` |
+
+## resplit Examples
+
+### PP=1 -> PP=4 (Qwen2.5-VL-7B)
+
+```bash
+mm-convert Qwen2_5_VLConverter resplit \
+  --cfg.source_dir "ckpt/mm_path/Qwen2.5-VL-7B-pp1" \
+  --cfg.target_dir "ckpt/mm_path/Qwen2.5-VL-7B-pp4" \
+  --cfg.source_parallel_config.llm_pp_layers [[28]] \
+  --cfg.source_parallel_config.vit_pp_layers [[32]] \
+  --cfg.target_parallel_config.llm_pp_layers [[1,10,10,7]] \
+  --cfg.target_parallel_config.vit_pp_layers [[32,0,0,0]] \
+  --cfg.target_parallel_config.tp_size 1
+```
+
+### PP=2 -> PP=4 (InternVL3-78B)
+
+```bash
+mm-convert InternVLConverter resplit \
+  --cfg.source_dir "ckpt/mm_path/InternVL3-78B-pp2" \
+  --cfg.target_dir "ckpt/mm_path/InternVL3-78B-pp4" \
+  --cfg.source_parallel_config.llm_pp_layers [[40,40]] \
+  --cfg.source_parallel_config.vit_pp_layers [[45,0]] \
+  --cfg.target_parallel_config.llm_pp_layers [[1,26,26,27]] \
+  --cfg.target_parallel_config.vit_pp_layers [[45,0,0,0]] \
+  --cfg.target_parallel_config.tp_size 2
+```
+
+## YAML Configuration File Examples
+
+### Qwen2.5-VL-7B hf_to_mm Configuration
+
+```yaml
+cfg:
+  mm_dir: "ckpt/mm_path/Qwen2.5-VL-7B-Instruct"
+  hf_config:
+    hf_dir: "ckpt/hf_path/Qwen2.5-VL-7B-Instruct"
+  parallel_config:
+    llm_pp_layers: [[1,10,10,7]]
+    vit_pp_layers: [[32,0,0,0]]
+    tp_size: 1
+```
+
+### InternVL3-78B hf_to_mm Configuration
+
+```yaml
+cfg:
+  mm_dir: "ckpt/mm_path/InternVL3-78B"
+  hf_config:
+    hf_dir: "ckpt/hf_path/InternVL3-78B"
+  parallel_config:
+    llm_pp_layers: [[1,26,26,27]]
+    vit_pp_layers: [[45,0,0,0]]
+    tp_size: 2
+```
+
+### WanConverter hf_to_mm Configuration
+
+```yaml
+cfg:
+  source_path: "./weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/"
+  target_path: "./weights/Wan-AI/Wan2.1-T2V-14B-Diffusers/transformer/"
+  target_parallel_config:
+    pp_layers: [[10,10,10,10]]
+```
+
+## Error Prevention Checklist
+
+- [ ] Confirm model family matches the Converter class (Qwen2VL vs Qwen2_5_VL)
+- [ ] hf_to_mm uses nested lists `[[...]]`, mm_to_hf uses 1D lists `[...]`
+- [ ] Sum of llm_pp_layers elements = total number of LLM layers
+- [ ] Sum of vit_pp_layers elements = total number of ViT layers
+- [ ] tp_size matches the TP value in the training script
+- [ ] PP splitting is consistent with pipeline_num_layers in model.json
+- [ ] For mm_to_hf, hf_config.hf_dir points to the original HF weights (with config.json)
+- [ ] WanConverter uses source_path/target_path parameters, not mm_dir
+- [ ] transformers version matches the model weights
+- [ ] LayerZero training weights need post-processing before conversion
+
+## Official References
+
+- [MindSpeed-MM Repository](https://gitcode.com/ascend/MindSpeed-MM)
+- [mm-convert Documentation](https://gitcode.com/ascend/MindSpeed-MM/blob/master/docs/features/mm_convert.md)


### PR DESCRIPTION
## 变更描述

### 变更类型
- [x] 新增 Skill
- [ ] 更新现有 Skill
- [ ] 修复问题
- [ ] 其他

### 涉及的 Skill
Skill 名称：mindspeed-mm-env-setup, mindspeed-mm-weight-prep, mindspeed-mm-vlm, mindspeed-mm-generative, mindspeed-mm-pipeline

### 变更内容摘要

新增 **MindSpeed-MM 系列 Skill**（5 个模块化子 Skill），覆盖华为昇腾 NPU 上 MindSpeed-MM 多模态大模型训练的完整流程。支持 40+ 模型，涵盖 VLM（理解）、生成（视频/图像）、全模态、音频四大类别。

#### Skill 列表

| Skill | 用途 | 核心内容 |
|-------|------|---------|
| `mindspeed-mm-env-setup` | 环境搭建 | CANN + PyTorch + torch_npu + MindSpeed + Megatron-LM + MindSpeed-MM 安装，版本冲突矩阵 |
| `mindspeed-mm-weight-prep` | 权重转换 | mm-convert CLI 工具，HF↔MM/DCP 格式转换，PP 重切分，多转换器参考 |
| `mindspeed-mm-vlm` | VLM 训练 | Qwen2.5VL/InternVL/GLM4V 等理解模型，Megatron/FSDP2/Custom 三种后端模式 |
| `mindspeed-mm-generative` | 生成模型训练 | Wan/HunyuanVideo/CogVideoX/FLUX 等模型，特征提取，四种后端模式 |
| `mindspeed-mm-pipeline` | 模型路由与索引 | 模型类型路由，完整模型注册表，通用训练参数参考 |

#### 文件结构

```
mindspeed-mm/
├── mindspeed-mm-env-setup/
│   ├── SKILL.md (297 行)
│   └── references/version-matrix.md
├── mindspeed-mm-weight-prep/
│   ├── SKILL.md (218 行)
│   └── references/conversion-guide.md
├── mindspeed-mm-vlm/
│   ├── SKILL.md (471 行)
│   └── references/
│       ├── data-format.md
│       ├── per-model-deps.md
│       └── model-delta-cards.md
├── mindspeed-mm-generative/
│   ├── SKILL.md (500 行)
│   └── references/
│       ├── feature-extraction.md
│       ├── per-model-deps.md
│       └── model-delta-cards.md
└── mindspeed-mm-pipeline/
    ├── SKILL.md (312 行)
    └── references/
        ├── common-args.md
        └── model-registry.md
```

所有 SKILL.md 均在 500 行限制以内，详细内容放在 `references/` 中按需加载。

---

## 检查清单

### SKILL.md 格式检查
- [x] `name` 字段与目录名完全匹配（5/5）
- [x] `description` 字段不少于 20 个字符（5/5）
- [x] frontmatter 格式正确（以 `---` 开头和结尾）
- [x] 包含 `description` 字段用于 Agent 匹配
- [x] 正文中无 `[TODO]` 或 `[TODO:xxx]` 占位符

### 内容完整性检查
- [x] 内部链接可正常访问
- [x] 代码块已标注语言（bash、python、yaml、json）
- [x] 表格格式正确

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`（作为 `mindspeed-mm-skills` 分组）
- [x] 已更新 `README.md` 中的 Skill 列表（5 个子 Skill 各一行）

---

## 测试说明

### 本地验证

#### 1. 验证脚本测试结果

```
$ python3 scripts/validate_skills.py | grep mindspeed-mm

✅ mindspeed-mm/mindspeed-mm-env-setup/SKILL.md
✅ mindspeed-mm/mindspeed-mm-generative/SKILL.md
✅ mindspeed-mm/mindspeed-mm-pipeline/SKILL.md
✅ mindspeed-mm/mindspeed-mm-vlm/SKILL.md
✅ mindspeed-mm/mindspeed-mm-weight-prep/SKILL.md
```

#### 2. Skill 功能测试（实机端到端验证）

- [x] 已在 AI Agent 中测试 Skill 触发
- [x] 已验证 Skill 内容正确加载

**测试环境**：8×Ascend 910B 服务器，Docker 容器（q3-skill-test:ready，--privileged --ipc=host）

**测试方式**：输入自然语言指令，Agent 调用 MindSpeed-MM Skill 完成模型训练全流程。

**测试 1：VLM 模型微调（Qwen2.5VL-3B）**

| 步骤 | 操作 | 结果 |
|------|------|------|
| 环境搭建 | 手动安装 PyTorch + torch_npu + MindSpeed + MindSpeed-MM | ✅ 8 NPU 就绪 |
| 权重转换 | mm-convert Qwen2_5_VLConverter hf_to_mm | ✅ 36 层 LLM + 32 层 ViT 转换成功 |
| 数据预处理 | LLaVA-Instruct-150K → MLLM JSON 格式 | ✅ 118K COCO2017 图像 + 150K 对话 |
| 训练 | 8 卡微调，10 iterations | ✅ Loss 1.27 → 1.22（正常下降） |

**测试 2：生成模型训练（Wan2.1-T2V-1.3B）**

| 步骤 | 操作 | 结果 |
|------|------|------|
| 环境搭建 | 手动安装 + diffusers==0.33.1 + 源码编译 decord | ✅ ARM aarch64 环境就绪 |
| 权重转换 | mm-convert WanConverter hf_to_mm | ✅ transformer 权重转换成功 |
| 特征提取 | get_wan_feature.py 提取 VAE + 文本编码器特征 | ✅ 10 个视频特征提取完成 |
| 训练 | 8 卡训练，10 iterations | ✅ Loss ~0.025（扩散模型预期范围） |

**训练结果**：
- VLM：Loss 1.27 → 1.22，~1.2s/iteration，无 NaN / 无跳过
- 生成：Loss ~0.025，~9.3s/iteration，无 NaN / 无跳过
- 所有 checkpoint 保存成功

#### 3. 事实核查

- [x] 所有入口脚本已与实际 shell 脚本逐一核对
- [x] 所有转换器类名已与源码核对
- [x] 所有 CLI 参数名已与 config dataclass 核对
- [x] 经过 4 轮 Codex 自动审查，累计发现并修复 15+ 事实错误

---

## 其他说明

### 关键设计决策

1. **按模型类别拆分**：VLM 和生成模型工作流差异大（入口脚本、数据格式、特征提取），拆为独立 Skill。
2. **通用模式 + Delta Cards**：每个 Skill 教授通用模式（Megatron/FSDP2/Custom），高差异模型通过 delta cards 补充执行清单。
3. **模型注册表**：完整的 40+ 模型查找表（后端、入口脚本、转换器、特征提取、依赖），Agent 可直接查表定位任意模型。
4. **官方方法优先**：安装流程遵循官方文档推荐的手动安装方式（非 install.sh），使用 Ascend PyTorch Releases 预编译 wheel。

### 关联 Issue
N/A

---
Submitted by: liangyuansheng / lllyys