### PR TITLE
feat: add verl-async-dapo and swanlab-setup skills

### DIFF
--- a/skills/swanlab-setup/SKILL.md
+++ b/skills/swanlab-setup/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: swanlab-setup
+description: SwanLab 实验追踪平台配置与登录管理。触发场景：(1) 配置 SwanLab 登录凭据 (2) 在容器内安装/登录 SwanLab (3) 为指定容器配置 SwanLab (4) 检查 SwanLab 连接状态。支持多种配置获取方式：环境变量、配置文件、交互式输入。可被其他 skill 通过 source scripts/functions.sh 调用。
+---
+
+# SwanLab 配置管理
+
+## 快速使用
+
+```bash
+# source 共享函数库
+source scripts/functions.sh
+
+# 在当前环境配置 SwanLab
+swanlab_setup
+
+# 为指定容器配置
+swanlab_setup_for_container my_container
+
+# 检查连接状态
+swanlab_check
+```
+
+## 配置获取优先级
+
+**环境变量 > 配置文件 > 交互式输入**
+
+| 方式 | 变量/路径 | 说明 |
+|------|-----------|------|
+| 环境变量 | `SWANLAB_HOST`, `SWANLAB_API_KEY` | 推荐方式 |
+| 配置文件 | `~/.verl/swanlab.conf` | 首次交互后自动保存 |
+| 交互式输入 | 终端提示 | 仅在交互式终端下触发 |
+
+## API
+
+脚本 `scripts/functions.sh` 提供 sourceable 函数：
+
+| 函数 | 用途 |
+|------|------|
+| `swanlab_clear_proxy` | 清除代理设置（SwanLab 连接需要） |
+| `swanlab_load_config` | 加载配置（环境变量 > 文件） |
+| `swanlab_save_config HOST KEY` | 保存配置到 `~/.verl/swanlab.conf` |
+| `swanlab_prompt_config` | 交互式获取配置 |
+| `swanlab_init` | 按优先级初始化配置 |
+| `swanlab_login` | 在当前环境执行 pip install + swanlab login |
+| `swanlab_setup` | 完整流程：clear_proxy + init + login |
+| `swanlab_setup_for_container NAME` | 在指定容器内执行 swanlab_setup |
+| `swanlab_check` | 检查登录状态和网络连通性 |
+
+## 其他 Skill 调用方式
+
+```bash
+# 1. 发现 skill 路径（推荐通过环境变量）
+SWANLAB_SETUP_PATH="${SWANLAB_SETUP_PATH:-$(dirname "$(find ~/.claude/skills/swanlab-setup -name functions.sh 2>/dev/null || echo "")")}"
+
+# 2. source 函数库
+source "$SWANLAB_SETUP_PATH/scripts/functions.sh"
+
+# 3. 调用
+swanlab_setup
+```
+
+## 脚本结构
+
+```
+swanlab-setup/
+├── SKILL.md              # 本文档
+└── scripts/
+    ├── functions.sh      # 共享函数库（被其他 skill source）
+    └── swanlab_check.sh  # 独立检查脚本
+```

--- a/skills/swanlab-setup/scripts/functions.sh
+++ b/skills/swanlab-setup/scripts/functions.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# functions.sh - SwanLab 共享函数库
+# 被其他 skill 通过 source 调用
+
+# 默认配置
+SWANLAB_DEFAULT_HOST="http://10.143.2.129:8000"
+SWANLAB_CONFIG_DIR="${HOME}/.verl"
+SWANLAB_CONFIG_FILE="${SWANLAB_CONFIG_DIR}/swanlab.conf"
+
+# 颜色
+_sl_red='\033[0;31m'
+_sl_green='\033[0;32m'
+_sl_yellow='\033[1;33m'
+_sl_blue='\033[0;34m'
+_sl_nc='\033[0m'
+
+_sl_info()  { echo -e "${_sl_blue}[SwanLab]${_sl_nc} $*"; }
+_sl_ok()    { echo -e "${_sl_green}[SwanLab]${_sl_nc} $*"; }
+_sl_warn()  { echo -e "${_sl_yellow}[SwanLab]${_sl_nc} $*"; }
+_sl_fail()  { echo -e "${_sl_red}[SwanLab]${_sl_nc} $*"; }
+
+# ==========================================
+# 代理设置
+# ==========================================
+
+# 清除代理设置（SwanLab 连接需要）
+swanlab_clear_proxy() {
+    unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
+    _sl_ok "已清除代理设置"
+}
+
+# ==========================================
+# 配置加载
+# ==========================================
+
+# 从环境变量或配置文件加载
+swanlab_load_config() {
+    SWANLAB_HOST="${SWANLAB_HOST:-}"
+    SWANLAB_API_KEY="${SWANLAB_API_KEY:-}"
+
+    if [ -z "$SWANLAB_HOST" ] || [ -z "$SWANLAB_API_KEY" ]; then
+        if [ -f "$SWANLAB_CONFIG_FILE" ]; then
+            # 安全地逐行读取，只导出已知变量
+            while IFS='=' read -r key value; do
+                [[ "$key" =~ ^#.*$ ]] && continue
+                [[ -z "$key" ]] && continue
+                value="${value%\"}" value="${value#\"}"
+                value="${value%\'}" value="${value#\'}"
+                case "$key" in
+                    SWANLAB_HOST)   SWANLAB_HOST="$value" ;;
+                    SWANLAB_API_KEY) SWANLAB_API_KEY="$value" ;;
+                esac
+            done < "$SWANLAB_CONFIG_FILE"
+        fi
+    fi
+
+    export SWANLAB_HOST SWANLAB_API_KEY
+}
+
+# 保存配置到文件
+swanlab_save_config() {
+    local host="$1"
+    local api_key="$2"
+
+    mkdir -p "$SWANLAB_CONFIG_DIR"
+    cat > "$SWANLAB_CONFIG_FILE" << EOF
+# SwanLab 配置文件（由 swanlab-setup skill 自动生成）
+SWANLAB_HOST="$host"
+SWANLAB_API_KEY="$api_key"
+EOF
+    chmod 600 "$SWANLAB_CONFIG_FILE"
+    _sl_ok "配置已保存到 $SWANLAB_CONFIG_FILE"
+}
+
+# 交互式获取配置
+swanlab_prompt_config() {
+    echo ""
+    echo "--- SwanLab 配置 ---"
+    echo "请提供以下信息（留空使用默认值）:"
+
+    read -p "SwanLab 主机地址 [$SWANLAB_DEFAULT_HOST]: " input_host
+    SWANLAB_HOST="${input_host:-$SWANLAB_DEFAULT_HOST}"
+
+    read -p "SwanLab API Key: " input_key
+    if [ -n "$input_key" ]; then
+        SWANLAB_API_KEY="$input_key"
+        swanlab_save_config "$SWANLAB_HOST" "$SWANLAB_API_KEY"
+    fi
+}
+
+# 按优先级初始化配置：环境变量 > 配置文件 > 交互式输入
+swanlab_init() {
+    swanlab_load_config
+
+    if [ -z "$SWANLAB_HOST" ] || [ -z "$SWANLAB_API_KEY" ]; then
+        if [ -t 0 ]; then
+            swanlab_prompt_config
+        else
+            SWANLAB_HOST="${SWANLAB_HOST:-$SWANLAB_DEFAULT_HOST}"
+            if [ -z "$SWANLAB_API_KEY" ]; then
+                _sl_warn "SwanLab API Key 未配置，请设置 SWANLAB_API_KEY 环境变量"
+            fi
+        fi
+    fi
+
+    export SWANLAB_HOST SWANLAB_API_KEY
+}
+
+# ==========================================
+# 安装与登录
+# ==========================================
+
+# 在当前环境执行安装和登录
+swanlab_login() {
+    # 确保配置已加载
+    swanlab_load_config
+
+    # 安装
+    if ! pip show swanlab &>/dev/null; then
+        _sl_info "安装 SwanLab..."
+        pip install swanlab -q
+    fi
+
+    # 登录
+    if [ -n "$SWANLAB_API_KEY" ]; then
+        _sl_info "登录 SwanLab (${SWANLAB_HOST:-$SWANLAB_DEFAULT_HOST})..."
+        echo "$SWANLAB_API_KEY" | swanlab login --host "${SWANLAB_HOST:-$SWANLAB_DEFAULT_HOST}" 2>&1 \
+            | grep -E "Login successfully|already logged" || _sl_ok "登录完成"
+    else
+        _sl_warn "SwanLab API Key 未设置，跳过登录"
+    fi
+}
+
+# ==========================================
+# 完整设置
+# ==========================================
+
+# 当前环境完整配置（clear_proxy + init + login）
+swanlab_setup() {
+    swanlab_clear_proxy
+    swanlab_init
+    swanlab_login
+}
+
+# 为指定容器配置 SwanLab
+swanlab_setup_for_container() {
+    local container="${1:?用法: swanlab_setup_for_container <container_name>}"
+
+    swanlab_init
+
+    local host="${SWANLAB_HOST:-$SWANLAB_DEFAULT_HOST}"
+    local key="${SWANLAB_API_KEY:-}"
+
+    _sl_info "为容器 $container 配置 SwanLab..."
+
+    docker exec "$container" bash -c "
+        # 清除代理
+        unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY no_proxy NO_PROXY
+        pip install swanlab -q 2>/dev/null || true
+        if [ -n '${key}' ]; then
+            echo '${key}' | swanlab login --host '${host}'
+        fi
+    "
+    _sl_ok "容器 $container SwanLab 配置完成"
+}
+
+# ==========================================
+# 状态检查
+# ==========================================
+
+# 检查 SwanLab 连接状态
+swanlab_check() {
+    echo "=========================================="
+    echo "SwanLab 状态检查"
+    echo "=========================================="
+
+    # 加载配置
+    swanlab_load_config
+
+    # 配置状态
+    if [ -n "$SWANLAB_HOST" ]; then
+        _sl_ok "Host: $SWANLAB_HOST"
+    else
+        _sl_fail "Host: 未配置"
+    fi
+
+    if [ -n "$SWANLAB_API_KEY" ]; then
+        _sl_ok "API Key: 已配置 (${#SWANLAB_API_KEY} chars)"
+    else
+        _sl_fail "API Key: 未配置"
+    fi
+
+    # 配置文件
+    if [ -f "$SWANLAB_CONFIG_FILE" ]; then
+        _sl_ok "配置文件: $SWANLAB_CONFIG_FILE"
+    else
+        _sl_warn "配置文件不存在 (首次交互后会自动创建)"
+    fi
+
+    # 安装状态
+    if pip show swanlab &>/dev/null; then
+        local ver
+        ver=$(pip show swanlab 2>/dev/null | grep Version | cut -d' ' -f2)
+        _sl_ok "已安装: swanlab $ver"
+    else
+        _sl_warn "未安装: pip install swanlab"
+    fi
+
+    # 网络连通性
+    if [ -n "$SWANLAB_HOST" ]; then
+        if curl -sf -o /dev/null --connect-timeout 5 "$SWANLAB_HOST"; then
+            _sl_ok "网络: 可连接"
+        else
+            _sl_fail "网络: 无法连接 $SWANLAB_HOST"
+        fi
+    fi
+
+    echo "=========================================="
+}

--- a/skills/swanlab-setup/scripts/swanlab_check.sh
+++ b/skills/swanlab-setup/scripts/swanlab_check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# swanlab_check.sh - SwanLab 独立检查脚本
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/functions.sh"
+
+swanlab_check

--- a/skills/verl-async-dapo/SKILL.md
+++ b/skills/verl-async-dapo/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: verl-async-dapo
+description: Verl 单异步 DAPO 训练配置生成器。触发场景：(1) 启动单异步 DAPO 训练 (2) 生成训练脚本 (3) 配置特性参数 (4) 训练前检查。**特性策略**：用户未指定时默认开启性能特性（flash_attn/dynamic_batch/remove_padding/gradient_checkpointing），显存特性（offload/recompute）默认关闭。OOM 时自动追加显存特性重试。**训练监控**：启动后输出 SwanLab 链接供用户自行查看，仅在错误时通知用户。**依赖 skill**：SwanLab 配置通过 swanlab-setup skill 提供。
+---
+
+# Verl 单异步 DAPO 训练
+
+## 交互式启动流程
+
+启动训练服务前，Agent **必须**按以下顺序询问用户：
+
+### 1. 容器选择
+```
+检测到以下容器：
+  [1] jins ( 运行中)
+  [2] 创建新容器
+
+请选择容器 (1/2):
+```
+
+### 2. 代理配置（如创建新容器或网络问题）
+```
+请提供代理配置（如不需要请回复"无"）：
+  http_proxy: ?
+  https_proxy: ?
+```
+
+### 3. 特性选择
+```
+是否有自定义特性需求？(回复"默认"使用默认配置)
+
+性能特性（默认全开）:
+  - flash_attn: Flash Attention 加速
+  - dynamic_batch: 动态 Batch Size
+  - remove_padding: Remove Padding 优化
+  - gradient_checkpointing: 梯度检查点
+
+显存特性（默认关闭，OOM 时自动开启）:
+  - offload: 参数/优化器卸载
+  - recompute: 重计算
+
+可选特性:
+  - prefix_cache: Prefix Cache
+  - chunked_prefill: Chunked Prefill
+```
+
+### 4. SwanLab 配置（如未配置）
+```
+SwanLab 监控配置：
+  Host: ?
+  API Key: ?
+```
+
+## 快速开始
+
+```bash
+# 方式 1: 快速启动脚本 (推荐)
+CONTAINER=jins TRAIN_STEPS=100 \
+SWANLAB_HOST=http://10.143.2.129:8000 \
+SWANLAB_API_KEY=your-key \
+bash scripts/quick_start.sh
+
+# 方式 2: 分步执行
+# 2.1 训练前检查
+bash scripts/preflight_check.sh
+
+# 2.2 启动单异步 DAPO 训练 (使用默认特性进行训练)
+export TRAIN_STEPS=4
+bash scripts/run_dapo.sh
+
+# 2.3 启动 One-Step-Off-Policy 训练
+export TRAIN_STEPS=4
+bash scripts/run_one_step_off_policy.sh
+```
+
+### One-Step-Off-Policy 训练
+
+One-Step-Off-Policy 是资源隔离的单异步训练模式，Trainer 和 Rollout 使用独立的 GPU 组。
+
+```bash
+# 基本用法
+export TRAIN_STEPS=100
+export TRAINER_GPUS=4
+export ROLLOUT_GPUS=4
+bash scripts/run_one_step_off_policy.sh
+
+# 启用 offload 特性
+export ENABLE_OFFLOAD=True
+bash scripts/run_one_step_off_policy.sh
+
+# FSDP2 框架
+export FRAMEWORK=fsdp
+bash scripts/run_one_step_off_policy.sh
+```
+
+**配置参数**:
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `FRAMEWORK` | `megatron` | 框架 (megatron/fsdp) |
+| `TRAINER_GPUS` | 4 | 训练 GPU 数 |
+| `ROLLOUT_GPUS` | 4 | Rollout GPU 数 |
+| `MAX_RESPONSE_LENGTH` | 8192 | 最大响应长度 |
+| `ENABLE_OFFLOAD` | False | 是否启用 offload |
+
+## SwanLab 配置
+
+SwanLab 配置由 **swanlab-setup skill** 提供，`common.sh` 启动时自动加载。详见 swanlab-setup skill 的 SKILL.md。
+
+配置按优先级自动获取：**环境变量 > 配置文件 > 交互式输入**
+
+```bash
+# 环境变量（推荐）
+export SWANLAB_HOST="http://your-swanlab-host:8000"
+export SWANLAB_API_KEY="your-api-key"
+```
+
+**重要**：必须在 `trainer.logger` 参数中包含 `"swanlab"` 才能启用监控：
+
+```bash
+# 正确的 logger 配置（启用 SwanLab 监控）
+trainer.logger='["console", "swanlab"]'
+
+# 仅控制台输出（不启用监控）
+trainer.logger='["console"]'
+```
+
+SwanLab 环境变量会自动被 verl tracking 模块读取：
+- `SWANLAB_API_KEY`: API 密钥
+- `SWANLAB_LOG_DIR`: 日志目录 (默认: swanlog)
+- `SWANLAB_MODE`: 模式 (cloud/local, 默认: cloud)
+
+## 代理配置
+
+```bash
+export http_proxy="http://your-proxy:8080"
+export https_proxy="http://your-proxy:8080"
+```
+
+## 训练监控策略
+
+**启动后行为**:
+1. 输出 SwanLab 链接供用户自行查看
+2. 后台静默运行，不实时推送进度
+3. **仅在错误时通知用户**（OOM、崩溃、配置错误等）
+
+**用户自行监控命令**:
+```bash
+# 查看当前进度
+docker exec {container} grep "Training Progress" /verl/train.log | tail -1
+
+# 实时跟踪日志
+docker exec {container} tail -f /verl/train.log
+
+# 检查是否出错
+docker exec {container} grep -E "Error|error|OOM|Exception" /verl/train.log | tail -10
+```
+
+## 特性管理策略
+
+### 特性分类
+
+| 类型 | 特性 | 默认状态 | 说明 |
+|------|------|----------|------|
+| **性能特性** | `flash_attn` | ✅ 默认开 | Flash Attention 加速 |
+| **性能特性** | `dynamic_batch` | ✅ 默认开 | 动态 Batch Size |
+| **性能特性** | `remove_padding` | ✅ 默认开 | Remove Padding 优化 |
+| **性能特性** | `gradient_checkpointing` | ✅ 默认开 | 梯度检查点 |
+| **显存特性** | `offload` | ❌ 默认关 | 参数/优化器卸载 (OOM 时自动追加) |
+| **显存特性** | `recompute` | ❌ 默认关 | 重计算 (OOM 时自动追加) |
+| **可选特性** | `prefix_cache` | ❌ 默认关 | Prefix Cache |
+| **可选特性** | `chunked_prefill` | ❌ 默认关 | Chunked Prefill |
+
+### 特性优先级
+
+```
+用户显式指定 > 默认性能特性 > OOM 自动追加显存特性
+```
+
+**重要**：
+- 用户未指定时 → 使用默认性能特性（全开）
+- OOM 时 → 自动追加显存特性（即使用户指定了其他特性）
+- 用户显式指定的特性永不移除，只在 OOM 时追加
+
+### OOM 自动恢复流程
+
+```
+启动训练 (默认性能特性)
+    ↓
+OOM 错误?
+    ├─ 是 → 追加 offload → 重试
+    │   └─ 仍 OOM → 追加 recompute → 重试
+    │       └─ 仍 OOM → 报告失败，建议调整参数
+    └─ 否 → 训练成功（静默完成）
+```
+
+## 配置参数
+
+### 环境变量
+
+| 变量 | 默认值 | 说明 |
+|------|--------|------|
+| `FRAMEWORK` | `megatron` | 框架 (megatron/fsdp) |
+| `MODEL_PATH` | Qwen3-8B | 模型路径 |
+| `TRAIN_FILE` | dapo-math-17k.parquet | 训练数据 |
+| `VAL_FILE` | aime-2024.parquet | 验证数据 |
+| `TRAIN_STEPS` | 100 | 训练步数 |
+| `TRAINER_GPUS` | 4 | 训练 GPU 数 |
+| `ROLLOUT_GPUS` | 4 | Rollout GPU 数 |
+| `USER_FEATURES` | (空) | 用户显式指定特性，逗号分隔 |
+| `MAX_OOM_RETRIES` | 2 | OOM 最大重试次数 |
+| `SWANLAB_HOST` | (从配置获取) | SwanLab 服务器地址 |
+| `SWANLAB_API_KEY` | (从配置获取) | SwanLab API 密钥 |
+
+## 详细参考
+
+- **完整工作流程**: See [references/workflow.md](references/workflow.md)
+- **参数详解**: See [references/params.md](references/params.md)
+- **故障排查**: See [references/troubleshooting.md](references/troubleshooting.md)

--- a/skills/verl-async-dapo/references/params.md
+++ b/skills/verl-async-dapo/references/params.md
@@ -1,0 +1,195 @@
+# 参数详解
+
+## 配置结构
+
+配置由以下 dataclass 组成：
+
+```python
+@dataclass
+class VerlConfig:
+    data: DataConfig           # 数据配置
+    algorithm: AlgorithmConfig # 算法配置
+    parallel: ParallelConfig   # 并行配置
+    rollout: RolloutConfig     # Rollout 配置
+    trainer: TrainerConfig     # 训练器配置
+    feature: FeatureConfig     # 特性开关
+    
+    model_path: str            # 模型路径
+    ckpts_dir: str             # Checkpoint 目录
+    learning_rate: float       # 学习率
+    trainer_gpus: int          # 训练 GPU 数
+    rollout_gpus: int          # Rollout GPU 数
+```
+
+---
+
+## DataConfig - 数据配置
+
+```python
+@dataclass
+class DataConfig:
+    train_files: str           # 训练数据路径
+    val_files: str             # 验证数据路径
+    prompt_key: str = "prompt" # Prompt 字段名
+    truncation: str = "left"   # 截断方式
+    max_prompt_length: int = 1024
+    max_response_length: int = 4096
+    train_batch_size: int = 8
+    filter_overlong_prompts: bool = True
+    filter_overlong_prompts_workers: int = 64
+```
+
+| 参数 | Hydra 路径 | 默认值 | 说明 |
+|------|-----------|--------|------|
+| train_files | `data.train_files` | - | 训练数据 parquet 文件 |
+| val_files | `data.val_files` | - | 验证数据 parquet 文件 |
+| max_prompt_length | `data.max_prompt_length` | 1024 | 最大 prompt 长度 |
+| max_response_length | `data.max_response_length` | 4096 | 最大响应长度 |
+| train_batch_size | `data.train_batch_size` | 8 | 训练 batch size |
+
+---
+
+## AlgorithmConfig - DAPO 算法配置
+
+```python
+@dataclass
+class AlgorithmConfig:
+    adv_estimator: str = "grpo"  # 使用 grpo 实现 DAPO
+    use_kl_in_reward: bool = False
+    kl_coef: float = 0.0
+    use_kl_loss: bool = False
+    kl_loss_coef: float = 0.0
+    clip_ratio_low: float = 0.2
+    clip_ratio_high: float = 0.28
+    clip_ratio_c: float = 10.0
+    entropy_coeff: float = 0.0
+```
+
+| 参数 | Hydra 路径 | 默认值 | 说明 |
+|------|-----------|--------|------|
+| adv_estimator | `algorithm.adv_estimator` | grpo | DAPO 使用 grpo |
+| clip_ratio_low | `++actor_rollout_ref.actor.clip_ratio_low` | 0.2 | 下裁剪比率 |
+| clip_ratio_high | `++actor_rollout_ref.actor.clip_ratio_high` | 0.28 | 上裁剪比率 |
+| clip_ratio_c | `++actor_rollout_ref.actor.clip_ratio_c` | 10.0 | DAPO c 参数 |
+
+**重要**: DAPO 通过 `reward_model.reward_manager=dapo` 启用。
+
+---
+
+## ParallelConfig - 并行配置 (Megatron)
+
+```python
+@dataclass
+class ParallelConfig:
+    gen_tp: int = 4    # 生成时张量并行
+    train_tp: int = 4  # 训练时张量并行
+    train_pp: int = 1  # 流水线并行
+    ppo_micro_batch_size_per_gpu: int = 2
+    ref_log_prob_micro_batch_size_per_gpu: int = 1
+    rollout_log_prob_micro_batch_size_per_gpu: int = 1
+```
+
+| 参数 | Hydra 路径 | 默认值 | 说明 |
+|------|-----------|--------|------|
+| train_tp | `actor_rollout_ref.actor.megatron.tensor_model_parallel_size` | 4 | 训练 TP |
+| train_pp | `actor_rollout_ref.actor.megatron.pipeline_model_parallel_size` | 1 | 训练 PP |
+| gen_tp | `actor_rollout_ref.rollout.tensor_model_parallel_size` | 4 | 生成 TP |
+
+**注意**: 异步模式下 `train_pp` 只能为 1。
+
+---
+
+## RolloutConfig - Rollout 配置
+
+```python
+@dataclass
+class RolloutConfig:
+    name: str = "vllm"
+    n_resp_per_prompt: int = 4
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = -1
+    gpu_memory_utilization: float = 0.80
+    enable_chunked_prefill: bool = True
+    enforce_eager: bool = True
+    load_format: str = "safetensors"
+```
+
+| 参数 | Hydra 路径 | 默认值 | 说明 |
+|------|-----------|--------|------|
+| name | `actor_rollout_ref.rollout.name` | vllm | **必须为 vllm** |
+| n_resp_per_prompt | `actor_rollout_ref.rollout.n` | 4 | 每个 prompt 生成响应数 |
+| gpu_memory_utilization | `actor_rollout_ref.rollout.gpu_memory_utilization` | 0.80 | vLLM 显存利用率 |
+| enable_chunked_prefill | `actor_rollout_ref.rollout.enable_chunked_prefill` | True | Chunked prefill |
+
+---
+
+## TrainerConfig - 训练器配置
+
+```python
+@dataclass
+class TrainerConfig:
+    project_name: str = "verl_async_dapo"
+    experiment_name: str = "DAPO-Qwen3-8b-async"
+    n_gpus_per_node: int = 8
+    nnodes: int = 1
+    total_epochs: int = 1
+    total_training_steps: int = 100
+    save_freq: int = 100
+    test_freq: int = -1
+    val_before_train: bool = False
+    device: str = "npu"
+    logger: str = '["console","swanlab"]'
+```
+
+| 参数 | Hydra 路径 | 默认值 | 说明 |
+|------|-----------|--------|------|
+| project_name | `trainer.project_name` | verl_async_dapo | 项目名 |
+| experiment_name | `trainer.experiment_name` | - | 实验名 |
+| total_training_steps | `trainer.total_training_steps` | 100 | 训练步数 |
+| device | `trainer.device` | npu | 设备类型 |
+
+---
+
+## FeatureConfig - 特性开关
+
+```python
+@dataclass
+class FeatureConfig:
+    offload: bool = False       # 参数卸载（OOM时自动开启）
+    recompute: bool = False     # 梯度检查点（OOM时自动开启）
+    flash_attn: bool = True     # Flash Attention
+    prefix_cache: bool = False  # Prefix Cache
+    dynamic_batch: bool = True  # 动态 Batch
+    remove_padding: bool = True # Remove Padding
+```
+
+| 特性 | Hydra 路径 | 默认 | 说明 |
+|------|-----------|------|------|
+| offload | `actor_rollout_ref.actor.megatron.*_offload` | False | 卸载到 CPU 节省显存 |
+| recompute | `actor_rollout_ref.model.enable_gradient_checkpointing` | False | 重计算节省显存 |
+| flash_attn | `++*.override_transformer_config.use_flash_attn` | True | Flash Attention |
+| prefix_cache | `actor_rollout_ref.rollout.enable_prefix_caching` | False | Prefix Cache |
+| dynamic_batch | `actor_rollout_ref.actor.use_dynamic_bsz` | True | 动态 Batch |
+
+---
+
+## CLI 参数映射
+
+| CLI 参数 | 配置字段 |
+|----------|----------|
+| `--model` | `model_path` |
+| `--train-data` | `data.train_files` |
+| `--val-data` | `data.val_files` |
+| `--steps` | `trainer.total_training_steps` |
+| `--epochs` | `trainer.total_epochs` |
+| `--exp-name` | `trainer.experiment_name` |
+| `--project` | `trainer.project_name` |
+| `--tp` | `parallel.train_tp` |
+| `--pp` | `parallel.train_pp` |
+| `--trainer-gpus` | `trainer_gpus` |
+| `--rollout-gpus` | `rollout_gpus` |
+| `--lr` | `learning_rate` |
+| `--ckpt-dir` | `ckpts_dir` |
+| `--framework` | (选择配置模板) |
+| `--feature` | (设置 feature.* 开关) |

--- a/skills/verl-async-dapo/references/troubleshooting.md
+++ b/skills/verl-async-dapo/references/troubleshooting.md
@@ -1,0 +1,64 @@
+# 故障排查
+
+## GPU 资源检测失败
+
+**错误**: `ValueError: Total available GPUs 0 is less than total desired GPUs 8`
+
+**原因**: NPU 环境下 Ray 无法自动检测 GPU，需要显式声明。
+
+**解决**:
+```bash
+# Ray 启动时显式指定 GPU 数
+ray start --head --num-gpus=8 --dashboard-port=8265
+
+# 或在代码中声明
+ray.init(num_gpus=8)
+```
+
+## OOM 错误
+
+脚本会自动处理 OOM：
+1. 第一次 OOM → 开启 `offload` 重试
+2. 第二次 OOM → 开启 `recompute` 重试
+3. 仍失败 → 建议：
+   - 减小 batch size
+   - 使用更小模型
+   - 减少 `max_response_length`
+
+## Ray 进程冲突
+
+```bash
+ray stop --force
+rm -rf /tmp/ray* ~/.ray /root/.ray /dev/shm/ray*
+```
+
+## 网络问题
+
+```bash
+# 设置代理（根据实际环境配置）
+export http_proxy=http://your-proxy:8080
+export https_proxy=http://your-proxy:8080
+```
+
+## SwanLab 未登录
+
+```bash
+# 设置环境变量后登录
+swanlab login --host $SWANLAB_HOST
+```
+
+## 查看日志
+
+```bash
+# 查看日志
+docker exec {container} tail -100 /verl/train.log
+
+# 检查 Ray 状态
+docker exec {container} ray status
+
+# 清理 Ray session
+docker exec {container} bash -c "ray stop --force && rm -rf /tmp/ray*"
+
+# 检查是否出错
+docker exec {container} grep -E "Error|error|OOM|Exception" /verl/train.log | tail -10
+```

--- a/skills/verl-async-dapo/references/workflow.md
+++ b/skills/verl-async-dapo/references/workflow.md
@@ -1,0 +1,189 @@
+# 完整工作流程
+
+## 1. 环境准备
+
+### 1.1 创建 Docker 容器
+
+```bash
+# 拉取镜像 (根据 NPU 类型)
+# A2 (910B/910B3)
+docker pull quay.io/ascend/verl:verl-8.3.rc1-910b-ubuntu22.04-py3.11-v0.7.0
+
+# A3 (Ascend 910)
+docker pull quay.io/ascend/verl:verl-8.3.rc1-a3-ubuntu22.04-py3.11-v0.7.0
+
+# 启动容器
+docker run -d --name verl_container \
+    --network host \
+    --privileged \
+    -v /usr/local/dcm:/usr/local/dcm \
+    -v /usr/local/sbin:/usr/local/sbin \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /mnt:/mnt \
+    -v /mnt2:/mnt2 \
+    quay.io/ascend/verl:verl-8.3.rc1-910b-ubuntu22.04-py3.11-v0.7.0 \
+    tail -f /dev/null
+```
+
+### 1.2 容器内环境配置
+
+```bash
+docker exec -it verl_container bash
+
+# 设置代理（根据实际环境配置）
+export http_proxy=http://your-proxy:8080
+export https_proxy=http://your-proxy:8080
+
+# 安装 SwanLab
+pip install swanlab
+
+# 登录 SwanLab（首次运行时会提示输入 API KEY）
+swanlab login --host http://your-swanlab-host:8000
+```
+
+## 2. 训练前检查
+
+```bash
+# 在 skill 目录下执行
+bash scripts/preflight_check.sh
+
+# 指定 0.6B 模型
+bash scripts/preflight_check.sh --model-size 0.6B
+
+# 自定义路径
+bash scripts/preflight_check.sh \
+    --model /path/to/model \
+    --train /path/to/train.parquet \
+    --val /path/to/val.parquet
+```
+
+**检查内容**:
+1. NPU 类型检测 → 推荐镜像
+2. 模型/训练数据/验证数据路径
+3. Docker 容器查找
+
+## 3. 生成配置
+
+### 3.1 使用 Python 配置生成器
+
+```bash
+# 查看帮助
+python config_generator.py --help
+
+# 生成默认脚本
+python config_generator.py --output run.sh
+
+# 自定义配置
+python config_generator.py \
+    --framework megatron \
+    --model /mnt2/metis/huggface_models/Qwen/Qwen3-8B \
+    --steps 10 \
+    --feature offload \
+    --output run.sh
+```
+
+### 3.2 输出格式
+
+**Shell 脚本** (默认):
+```bash
+python config_generator.py --output run.sh
+# 生成可执行的 shell 脚本
+```
+
+**命令行参数**:
+```bash
+python config_generator.py --format args
+# 直接打印 Hydra 命令行参数
+# 可用于复制粘贴或管道
+```
+
+**YAML 配置**:
+```bash
+python config_generator.py --format yaml
+# 输出 YAML 格式的配置
+```
+
+## 4. 启动训练
+
+### 方式1: 运行生成的脚本
+
+```bash
+bash run.sh
+```
+
+### 方式2: 使用启动脚本
+
+```bash
+# 设置环境变量
+export FRAMEWORK=megatron
+export TRAIN_STEPS=10
+export ENABLE_OFFLOAD=true
+
+# 运行
+bash scripts/run_dapo.sh
+```
+
+### 方式3: 直接执行命令
+
+```bash
+# 生成命令并直接执行
+python config_generator.py --format args | bash
+```
+
+## 5. 监控训练
+
+### 5.1 查看日志
+
+```bash
+# 实时查看
+tail -f logs/DAPO-Qwen3-8b-megatron-async_*.log
+
+# 搜索错误
+grep -i "error" logs/*.log
+```
+
+### 5.2 SwanLab Dashboard
+
+访问: `{SWANLAB_HOST}/@{SWANLAB_USER}/verl_hlm`
+
+### 5.3 训练进度
+
+```
+Training Progress:  20%|██        | 2/10 [05:10<20:40, 155.81s/it]
+```
+
+## 6. Checkpoint
+
+### 6.1 保存位置
+
+```
+/mnt/project/jins/ckpt/{exp_name}/global_step_N/
+```
+
+### 6.2 恢复训练
+
+设置 `trainer.resume_mode=auto`
+
+## 常见问题
+
+### Ray 进程冲突
+
+```bash
+ray stop --force
+rm -rf /tmp/ray* ~/.ray /root/.ray /dev/shm/ray*
+```
+
+### 网络问题
+
+```bash
+# 设置代理（根据实际环境配置）
+export http_proxy=http://your-proxy:8080
+export https_proxy=http://your-proxy:8080
+```
+
+### SwanLab 未登录
+
+```bash
+# 设置环境变量后登录
+swanlab login --host $SWANLAB_HOST
+```

--- a/skills/verl-async-dapo/scripts/common.sh
+++ b/skills/verl-async-dapo/scripts/common.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+# common.sh - Verl 异步 DAPO 共享函数库
+# 被训练脚本 source 使用
+
+set -euo pipefail
+
+# ==========================================
+# 颜色定义 (必须最先定义，供后续函数使用)
+# ==========================================
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# ==========================================
+# 打印函数
+# ==========================================
+
+info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+fail()  { echo -e "${RED}[FAIL]${NC} $*"; }
+
+# ==========================================
+# SwanLab Skill 集成
+# ==========================================
+
+# 查找 swanlab-setup skill 路径
+_swanlab_setup_path() {
+    local skill_dir="${HOME}/.claude/skills/swanlab-setup"
+    # Windows 路径兼容
+    if [ ! -d "$skill_dir" ]; then
+        skill_dir="/root/.claude/skills/swanlab-setup"
+    fi
+    local functions_file="${skill_dir}/scripts/functions.sh"
+    if [ -f "$functions_file" ]; then
+        echo "$functions_file"
+        return 0
+    fi
+    return 1
+}
+
+# 加载 SwanLab 函数（失败时打印警告但不阻断）
+if _swanlab_path=$(_swanlab_setup_path) 2>/dev/null; then
+    # shellcheck source=/dev/null
+    source "$_swanlab_path"
+    info "SwanLab 函数库已加载"
+else
+    # 提供哑桩函数，避免其他脚本因函数不存在而失败
+    warn "未找到 swanlab-setup skill，SwanLab 相关功能不可用"
+    init_swanlab_config() { :; }
+    setup_swanlab_in_container() { :; }
+    setup_swanlab_for_container() { :; }
+fi
+
+# ==========================================
+# 默认配置
+# ==========================================
+
+DEFAULT_CONTAINER="jins"
+DEFAULT_PROJECT_NAME="verl_async_dapo"
+DEFAULT_MODEL_8B="/mnt/public/models/huggface_models/Qwen/Qwen3-8B"
+DEFAULT_MODEL_06B="/mnt/public/models/huggface_models/Qwen/Qwen3-0.6B"
+DEFAULT_TRAIN_DATA="/mnt2/wql/data/dapo-math-17k.parquet"
+DEFAULT_VAL_DATA="/mnt2/wql/data/aime-2024.parquet"
+DEFAULT_PROXY=""
+
+# ==========================================
+# 代理配置
+# ==========================================
+
+load_proxy_config() {
+    # 同时检查大写和小写环境变量
+    if [ -n "${http_proxy:-}" ]; then
+        DEFAULT_PROXY="$http_proxy"
+    elif [ -n "${HTTP_PROXY:-}" ]; then
+        DEFAULT_PROXY="$HTTP_PROXY"
+    elif [ -n "${https_proxy:-}" ]; then
+        DEFAULT_PROXY="$https_proxy"
+    elif [ -n "${HTTPS_PROXY:-}" ]; then
+        DEFAULT_PROXY="$HTTPS_PROXY"
+    fi
+}
+
+setup_proxy() {
+    export http_proxy="${http_proxy:-$DEFAULT_PROXY}"
+    export https_proxy="${https_proxy:-$DEFAULT_PROXY}"
+}
+
+# ==========================================
+# 路径检查
+# ==========================================
+
+check_path() {
+    local path="$1" desc="$2"
+    if [ -z "$path" ]; then
+        warn "${desc}: 未指定"
+        return 1
+    fi
+    if [ -e "$path" ]; then
+        local size
+        size=$( [ -f "$path" ] && du -h "$path" | cut -f1 || du -sh "$path" | cut -f1 )
+        ok "${desc}: ${path} (${size})"
+        return 0
+    else
+        fail "${desc}: ${path} 不存在!"
+        return 1
+    fi
+}
+
+# ==========================================
+# 模型路径解析
+# ==========================================
+
+get_default_model() {
+    case "${MODEL_SIZE:-8B}" in
+        0.6B|0.6) echo "$DEFAULT_MODEL_06B" ;;
+        *)        echo "$DEFAULT_MODEL_8B" ;;
+    esac
+}
+
+# ==========================================
+# 验证所有路径
+# ==========================================
+
+validate_all_paths() {
+    local model_path="${1:-$(get_default_model)}"
+    local train_data="${2:-$DEFAULT_TRAIN_DATA}"
+    local val_data="${3:-$DEFAULT_VAL_DATA}"
+    local errors=0
+
+    echo "--- 路径验证 ---"
+    check_path "$model_path" "模型" || ((errors++))
+    check_path "$train_data" "训练数据" || ((errors++))
+    check_path "$val_data"   "验证数据" || ((errors++))
+
+    export VALIDATED_MODEL_PATH="$model_path"
+    export VALIDATED_TRAIN_DATA="$train_data"
+    export VALIDATED_VAL_DATA="$val_data"
+
+    return $errors
+}
+
+# ==========================================
+# Ray 进程清理
+# ==========================================
+
+cleanup_ray() {
+    info "清理 Ray 进程..."
+    ray stop --force 2>/dev/null || true
+    sleep 1
+    pkill -9 ray 2>/dev/null || true
+    rm -rf /tmp/ray
+}
+
+# ==========================================
+# Ray 启动（NPU 环境需显式声明 GPU）
+# ==========================================
+
+start_ray_head() {
+    local num_gpus="${1:-8}"
+    local dashboard_port="${2:-8265}"
+    
+    info "启动 Ray Head 节点 (GPUs: $num_gpus, Dashboard: $dashboard_port)..."
+    
+    # NPU 环境下 Ray 无法自动检测 GPU，必须显式声明
+    ray start --head \
+        --num-gpus=$num_gpus \
+        --dashboard-port=$dashboard_port \
+        --port=6379 \
+        2>&1 | grep -E "SUCC|INFO|ERROR|WARN" | tail -10
+    
+    # 等待 Ray 就绪
+    sleep 3
+    
+    # 验证 Ray 状态
+    if ray status 2>&1 | grep -q "Active:"; then
+        ok "Ray 集群启动成功"
+    else
+        fail "Ray 集群启动失败"
+        return 1
+    fi
+}
+
+# ==========================================
+# SwanLab 配置兼容层 (调用 swanlab-setup)
+# ==========================================
+
+# 初始化 SwanLab 配置（环境变量 > 配置文件 > 交互式输入）
+init_swanlab_config() {
+    if declare -f swanlab_init &>/dev/null; then
+        swanlab_init
+    else
+        warn "swanlab_init 不可用"
+    fi
+}
+
+# 在容器内配置 SwanLab
+setup_swanlab_in_container() {
+    if declare -f swanlab_setup &>/dev/null; then
+        swanlab_setup
+    else
+        warn "swanlab_setup 不可用"
+    fi
+}
+
+# 为指定容器配置 SwanLab
+setup_swanlab_for_container() {
+    local container="${1:-$DEFAULT_CONTAINER}"
+    if declare -f swanlab_setup_for_container &>/dev/null; then
+        swanlab_setup_for_container "$container"
+    else
+        warn "swanlab_setup_for_container 不可用"
+    fi
+}
+
+# ==========================================
+# 资源分配 (异步模式)
+# ==========================================
+
+auto_allocate_gpus() {
+    local npu_count="${1:-8}"
+    TRAINER_GPUS="${VERL_TRAINER_GPUS:-$((npu_count / 2))}"
+    ROLLOUT_GPUS="${VERL_ROLLOUT_GPUS:-$((npu_count / 2))}"
+}

--- a/skills/verl-async-dapo/scripts/config_generator.py
+++ b/skills/verl-async-dapo/scripts/config_generator.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""
+Verl 异步 DAPO 训练配置生成器
+生成 Hydra 命令行参数或 Shell 脚本
+"""
+
+import argparse
+import os
+from dataclasses import dataclass, asdict, field
+from pathlib import Path
+from typing import Optional, List, Dict, Any
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
+
+
+# ==========================================
+# 配置数据类
+# ==========================================
+
+@dataclass
+class DataConfig:
+    """数据配置"""
+    train_files: str = "/mnt2/wql/data/dapo-math-17k.parquet"
+    val_files: str = "/mnt2/wql/data/aime-2024.parquet"
+    prompt_key: str = "prompt"
+    truncation: str = "left"
+    max_prompt_length: int = 1024
+    max_response_length: int = 4096
+    train_batch_size: int = 8
+    filter_overlong_prompts: bool = True
+    filter_overlong_prompts_workers: int = 64
+
+
+@dataclass
+class AlgorithmConfig:
+    """DAPO 算法配置"""
+    adv_estimator: str = "grpo"  # grpo for DAPO
+    use_kl_in_reward: bool = False
+    kl_coef: float = 0.0
+    use_kl_loss: bool = False
+    kl_loss_coef: float = 0.0
+    clip_ratio_low: float = 0.2
+    clip_ratio_high: float = 0.28
+    clip_ratio_c: float = 10.0
+    entropy_coeff: float = 0.0
+
+
+@dataclass
+class ParallelConfig:
+    """并行配置 (Megatron)"""
+    gen_tp: int = 4  # 生成时张量并行
+    train_tp: int = 4  # 训练时张量并行
+    train_pp: int = 1  # 流水线并行 (异步模式只能为1)
+    ppo_micro_batch_size_per_gpu: int = 2
+    ref_log_prob_micro_batch_size_per_gpu: int = 1
+    rollout_log_prob_micro_batch_size_per_gpu: int = 1
+
+
+@dataclass
+class RolloutConfig:
+    """Rollout 配置"""
+    name: str = "vllm"
+    n_resp_per_prompt: int = 4
+    temperature: float = 1.0
+    top_p: float = 1.0
+    top_k: int = -1
+    gpu_memory_utilization: float = 0.80
+    enable_chunked_prefill: bool = True
+    enforce_eager: bool = True
+    load_format: str = "safetensors"
+
+
+@dataclass
+class TrainerConfig:
+    """训练器配置"""
+    project_name: str = "verl_async_dapo"
+    experiment_name: str = "DAPO-Qwen3-8b-async"
+    n_gpus_per_node: int = 8
+    nnodes: int = 1
+    total_epochs: int = 1
+    total_training_steps: int = 100
+    save_freq: int = 100
+    test_freq: int = -1
+    val_before_train: bool = False
+    device: str = "npu"
+    logger: str = '["console","swanlab"]'
+
+
+@dataclass
+class FeatureConfig:
+    """特性开关配置（性能特性默认开启，显存特性默认关闭）"""
+    offload: bool = False
+    recompute: bool = False
+    flash_attn: bool = True
+    prefix_cache: bool = False
+    dynamic_batch: bool = True
+    remove_padding: bool = True
+
+
+@dataclass
+class VerlConfig:
+    """Verl 完整配置"""
+    data: DataConfig = field(default_factory=DataConfig)
+    algorithm: AlgorithmConfig = field(default_factory=AlgorithmConfig)
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    rollout: RolloutConfig = field(default_factory=RolloutConfig)
+    trainer: TrainerConfig = field(default_factory=TrainerConfig)
+    feature: FeatureConfig = field(default_factory=FeatureConfig)
+    
+    model_path: str = "/mnt2/metis/huggface_models/Qwen/Qwen3-8B"
+    ckpts_dir: str = "/mnt/project/jins/ckpt/DAPO-Qwen3-8B"
+    learning_rate: float = 1e-6
+    weight_decay: float = 0.1
+    
+    # 资源分配 (异步模式)
+    trainer_gpus: int = 4
+    rollout_gpus: int = 4
+
+
+# ==========================================
+# 命令行参数生成
+# ==========================================
+
+def generate_command_args(config: VerlConfig, framework: str = "megatron") -> List[str]:
+    """生成 Hydra 命令行参数列表"""
+    
+    args = [
+        "python3", "-m", "recipe.one_step_off_policy.main_ppo",
+        "--config-path=config",
+        f"--config-name=one_step_off_ppo_{'megatron_' if framework == 'megatron' else ''}trainer.yaml",
+    ]
+    
+    # ========== 基础参数 (必须传递) ==========
+    args.extend([
+        # 数据配置
+        f"data.train_files={config.data.train_files}",
+        f"data.val_files={config.data.val_files}",
+        f"data.max_prompt_length={config.data.max_prompt_length}",
+        f"data.max_response_length={config.data.max_response_length}",
+        f"data.train_batch_size={config.data.train_batch_size}",
+        f"data.filter_overlong_prompts={config.data.filter_overlong_prompts}",
+        f"data.filter_overlong_prompts_workers={config.data.filter_overlong_prompts_workers}",
+        f"data.truncation={config.data.truncation}",
+        
+        # 模型路径
+        f"actor_rollout_ref.model.path={config.model_path}",
+        
+        # 训练配置
+        f"trainer.total_training_steps={config.trainer.total_training_steps}",
+        f"trainer.experiment_name={config.trainer.experiment_name}",
+        f"trainer.device={config.trainer.device}",
+    ])
+    
+    # ========== 算法配置 ==========
+    args.extend([
+        f"algorithm.adv_estimator={config.algorithm.adv_estimator}",
+        f"algorithm.use_kl_in_reward={config.algorithm.use_kl_in_reward}",
+        f"++actor_rollout_ref.actor.clip_ratio_low={config.algorithm.clip_ratio_low}",
+        f"++actor_rollout_ref.actor.clip_ratio_high={config.algorithm.clip_ratio_high}",
+        f"++actor_rollout_ref.actor.clip_ratio_c={config.algorithm.clip_ratio_c}",
+        f"actor_rollout_ref.actor.use_kl_loss={config.algorithm.use_kl_loss}",
+        f"actor_rollout_ref.actor.kl_loss_coef={config.algorithm.kl_loss_coef}",
+        f"actor_rollout_ref.actor.entropy_coeff={config.algorithm.entropy_coeff}",
+        f"reward_model.reward_manager=dapo",
+        
+        # DAPO overlong buffer 配置 (必须包含所有字段，否则会报 ConfigAttributeError)
+        f"+reward_model.reward_kwargs.overlong_buffer_cfg.enable=True",
+        f"+reward_model.reward_kwargs.overlong_buffer_cfg.len={config.data.max_response_length}",
+        f"+reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=1.0",
+        f"+reward_model.reward_kwargs.overlong_buffer_cfg.log=False",
+        f"+reward_model.reward_kwargs.max_resp_len={config.data.max_response_length}",
+    ])
+    
+    # ========== 框架配置 ==========
+    if framework == "megatron":
+        args.extend(_generate_megatron_args(config))
+    else:
+        args.extend(_generate_fsdp_args(config))
+    
+    # ========== Rollout 配置 ==========
+    args.extend([
+        f"actor_rollout_ref.rollout.name={config.rollout.name}",
+        f"actor_rollout_ref.rollout.n={config.rollout.n_resp_per_prompt}",
+        f"actor_rollout_ref.rollout.temperature={config.rollout.temperature}",
+        f"actor_rollout_ref.rollout.top_p={config.rollout.top_p}",
+        f"actor_rollout_ref.rollout.gpu_memory_utilization={config.rollout.gpu_memory_utilization}",
+        f"actor_rollout_ref.rollout.enforce_eager={config.rollout.enforce_eager}",
+        f"actor_rollout_ref.rollout.load_format={config.rollout.load_format}",
+        f"actor_rollout_ref.rollout.enable_chunked_prefill={config.rollout.enable_chunked_prefill}",
+    ])
+    
+    # ========== Trainer 配置 ==========
+    args.extend([
+        f"trainer.project_name={config.trainer.project_name}",
+        f"trainer.nnodes={config.trainer.nnodes}",
+        f"trainer.n_gpus_per_node={config.trainer_gpus}",
+        f"trainer.total_epochs={config.trainer.total_epochs}",
+        f"trainer.default_local_dir={config.ckpts_dir}",
+        f"trainer.save_freq={config.trainer.save_freq}",
+        f"trainer.test_freq={config.trainer.test_freq}",
+        f"trainer.val_before_train={config.trainer.val_before_train}",
+        f"trainer.logger='{config.trainer.logger}'",
+        f"rollout.nnodes={config.trainer.nnodes}",
+        f"rollout.n_gpus_per_node={config.rollout_gpus}",
+    ])
+    
+    # ========== 学习率 ==========
+    args.append(f"actor_rollout_ref.actor.optim.lr={config.learning_rate}")
+    
+    # ========== 特性参数 ==========
+    args.extend(_generate_feature_args(config, framework))
+    
+    return args
+
+
+def _generate_megatron_args(config: VerlConfig) -> List[str]:
+    """生成 Megatron 框架参数"""
+    args = [
+        "actor_rollout_ref.actor.strategy=megatron",
+        "critic.strategy=megatron",
+        "actor_rollout_ref.hybrid_engine=False",
+        
+        # 并行配置
+        f"actor_rollout_ref.actor.megatron.tensor_model_parallel_size={config.parallel.train_tp}",
+        f"actor_rollout_ref.actor.megatron.pipeline_model_parallel_size={config.parallel.train_pp}",
+        f"actor_rollout_ref.rollout.tensor_model_parallel_size={config.parallel.gen_tp}",
+        f"actor_rollout_ref.ref.megatron.tensor_model_parallel_size={config.parallel.train_tp}",
+        f"actor_rollout_ref.ref.megatron.pipeline_model_parallel_size={config.parallel.train_pp}",
+        
+        # Batch 配置
+        f"actor_rollout_ref.actor.ppo_mini_batch_size=8",
+        f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu={config.parallel.ppo_micro_batch_size_per_gpu}",
+        f"actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu={config.parallel.rollout_log_prob_micro_batch_size_per_gpu}",
+        f"actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu={config.parallel.ref_log_prob_micro_batch_size_per_gpu}",
+        
+        # 其他
+        "actor_rollout_ref.actor.use_torch_compile=False",
+        "actor_rollout_ref.ref.use_torch_compile=False",
+    ]
+    return args
+
+
+def _generate_fsdp_args(config: VerlConfig) -> List[str]:
+    """生成 FSDP2 框架参数"""
+    args = [
+        "actor_rollout_ref.actor.strategy=fsdp2",
+        "critic.strategy=fsdp2",
+        "actor_rollout_ref.ref.strategy=fsdp2",
+        "reward_model.strategy=fsdp2",
+        "actor_rollout_ref.hybrid_engine=False",
+        
+        # Batch 配置
+        f"actor_rollout_ref.actor.ppo_mini_batch_size=128",
+        f"actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=8",
+        f"critic.ppo_mini_batch_size=128",
+        f"critic.ppo_micro_batch_size_per_gpu=8",
+        
+        # 模型路径
+        f"critic.model.path={config.model_path}",
+        f"reward_model.model.path={config.model_path}",
+        
+        "actor_rollout_ref.actor.use_torch_compile=False",
+    ]
+    return args
+
+
+def _generate_feature_args(config: VerlConfig, framework: str) -> List[str]:
+    """生成特性参数"""
+    args = []
+    
+    # Offload
+    if config.feature.offload and framework == "megatron":
+        args.extend([
+            "actor_rollout_ref.actor.megatron.param_offload=True",
+            "actor_rollout_ref.actor.megatron.optimizer_offload=True",
+            "actor_rollout_ref.actor.megatron.grad_offload=True",
+        ])
+    
+    # Recompute / Gradient Checkpointing
+    args.append(f"actor_rollout_ref.model.enable_gradient_checkpointing={config.feature.recompute}")
+    
+    # Flash Attention (Megatron)
+    if framework == "megatron" and config.feature.flash_attn:
+        args.extend([
+            "++actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=True",
+            "++actor_rollout_ref.ref.megatron.override_transformer_config.use_flash_attn=True",
+            "++critic.megatron.override_transformer_config.use_flash_attn=True",
+        ])
+    
+    # Remove Padding
+    if framework == "megatron" and config.feature.remove_padding:
+        args.append("actor_rollout_ref.model.use_remove_padding=True")
+    
+    # Prefix Cache
+    if config.feature.prefix_cache:
+        args.append("actor_rollout_ref.rollout.enable_prefix_caching=True")
+    
+    # Dynamic Batch
+    if config.feature.dynamic_batch:
+        args.extend([
+            "actor_rollout_ref.actor.use_dynamic_bsz=True",
+            "actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True",
+            "actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True",
+        ])
+    
+    return args
+
+
+# ==========================================
+# Shell 脚本生成
+# ==========================================
+
+def generate_shell_script(config: VerlConfig, framework: str = "megatron", output_path: str = None) -> str:
+    """生成完整的 Shell 脚本"""
+    args = generate_command_args(config, framework)
+    
+    # 格式化命令
+    cmd_lines = []
+    for i, arg in enumerate(args[2:]):  # 跳过 python3 -m
+        if i == 0:
+            cmd_lines.append(f"    {arg}")
+        else:
+            cmd_lines.append(f"    {arg}")
+    
+    cmd_str = " \\\n".join(cmd_lines)
+    
+    script = f'''#!/bin/bash
+# 自动生成的 Verl 异步 DAPO 训练脚本
+# 框架: {framework.upper()}
+# 项目: {config.trainer.project_name}
+# 实验: {config.trainer.experiment_name}
+
+set -euo pipefail
+
+# 环境变量
+export VLLM_ASCEND_ENABLE_NZ=0
+export HCCL_EXEC_TIMEOUT=60000
+export HCCL_CONNECT_TIMEOUT=7200
+
+echo "=========================================="
+echo "Verl 异步 DAPO 训练"
+echo "框架: {framework.upper()}"
+echo "项目: {config.trainer.project_name}"
+echo "实验: {config.trainer.experiment_name}"
+echo "步数: {config.trainer.total_training_steps}"
+echo "资源: trainer={config.trainer_gpus}, rollout={config.rollout_gpus}"
+echo "=========================================="
+
+cd /verl
+
+python3 -m {args[3]} \\
+{cmd_str} 2>&1 | tee "logs/{config.trainer.experiment_name}_$(date +%Y%m%d_%H%M).log"
+'''
+    
+    if output_path:
+        with open(output_path, 'w') as f:
+            f.write(script)
+        os.chmod(output_path, 0o755)
+        return output_path
+    
+    return script
+
+
+# ==========================================
+# 配置合并
+# ==========================================
+
+def merge_config(base: VerlConfig, overrides: Dict[str, Any]) -> VerlConfig:
+    """合并用户覆盖配置"""
+    for key, value in overrides.items():
+        parts = key.split('.')
+        obj = base
+        
+        for part in parts[:-1]:
+            if hasattr(obj, part):
+                obj = getattr(obj, part)
+            else:
+                break
+        else:
+            if hasattr(obj, parts[-1]):
+                setattr(obj, parts[-1], value)
+    
+    return base
+
+
+# ==========================================
+# CLI 入口
+# ==========================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Verl 异步 DAPO 配置生成器",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+示例:
+  # 生成默认配置的 shell 脚本
+  python config_generator.py --output run_train.sh
+  
+  # 生成 Megatron 框架脚本
+  python config_generator.py --framework megatron --steps 10 --output run_megatron.sh
+  
+  # 生成 FSDP2 框架脚本
+  python config_generator.py --framework fsdp --output run_fsdp.sh
+  
+  # 启用 offload 特性
+  python config_generator.py --feature offload --output run_offload.sh
+  
+  # 只打印命令行参数
+  python config_generator.py --format args
+"""
+    )
+    
+    # 输出选项
+    parser.add_argument("--output", "-o", default=None, help="输出脚本路径")
+    parser.add_argument("--format", choices=["shell", "args", "yaml"], default="shell", help="输出格式")
+    parser.add_argument("--framework", choices=["megatron", "fsdp"], default="megatron", help="训练框架")
+    
+    # 基础参数
+    parser.add_argument("--model", default="/mnt2/metis/huggface_models/Qwen/Qwen3-8B", help="模型路径")
+    parser.add_argument("--train-data", default="/mnt2/wql/data/dapo-math-17k.parquet", help="训练数据路径")
+    parser.add_argument("--val-data", default="/mnt2/wql/data/aime-2024.parquet", help="验证数据路径")
+    parser.add_argument("--bsz", type=int, default=8, help="训练 batch size")
+    parser.add_argument("--lr", type=float, default=1e-6, help="学习率")
+    parser.add_argument("--steps", type=int, default=100, help="训练步数")
+    parser.add_argument("--epochs", type=int, default=1, help="训练轮数")
+    parser.add_argument("--exp-name", default=None, help="实验名称")
+    parser.add_argument("--project", default="verl_async_dapo", help="项目名称")
+    
+    # 路径配置
+    parser.add_argument("--ckpt-dir", default="/mnt/project/jins/ckpt/DAPO-Qwen3-8B", help="checkpoint 目录")
+    
+    # 并行配置
+    parser.add_argument("--tp", type=int, default=4, help="张量并行度")
+    parser.add_argument("--pp", type=int, default=1, help="流水线并行度 (异步模式只能为1)")
+    parser.add_argument("--nodes", type=int, default=1, help="节点数")
+    
+    # 资源分配
+    parser.add_argument("--trainer-gpus", type=int, default=4, help="训练 GPU 数")
+    parser.add_argument("--rollout-gpus", type=int, default=4, help="Rollout GPU 数")
+    
+    # 特性配置
+    parser.add_argument("--feature", nargs="*", default=[], 
+                        choices=["offload", "recompute", "flash_attn", "prefix_cache", "dynamic_batch", "remove_padding"],
+                        help="启用的特性列表")
+    
+    args = parser.parse_args()
+    
+    # 解析特性
+    features = set(args.feature)
+    
+    # 构建配置
+    config = VerlConfig(
+        data=DataConfig(
+            train_files=args.train_data,
+            val_files=args.val_data,
+            train_batch_size=args.bsz,
+        ),
+        algorithm=AlgorithmConfig(),
+        parallel=ParallelConfig(
+            gen_tp=args.tp,
+            train_tp=args.tp,
+            train_pp=args.pp,
+        ),
+        rollout=RolloutConfig(),
+        trainer=TrainerConfig(
+            project_name=args.project,
+            experiment_name=args.exp_name or f"DAPO-Qwen3-8b-{args.framework}-async",
+            nnodes=args.nodes,
+            total_training_steps=args.steps,
+            total_epochs=args.epochs,
+        ),
+        feature=FeatureConfig(
+            offload="offload" in features,
+            recompute="recompute" in features,
+            flash_attn="flash_attn" in features,
+            prefix_cache="prefix_cache" in features,
+            dynamic_batch="dynamic_batch" in features,
+            remove_padding="remove_padding" in features,
+        ),
+        model_path=args.model,
+        ckpts_dir=args.ckpt_dir,
+        learning_rate=args.lr,
+        trainer_gpus=args.trainer_gpus,
+        rollout_gpus=args.rollout_gpus,
+    )
+    
+    # 输出
+    if args.format == "shell":
+        if args.output:
+            output = generate_shell_script(config, args.framework, args.output)
+            print(f"✅ 生成脚本: {output}")
+        else:
+            print(generate_shell_script(config, args.framework))
+    
+    elif args.format == "args":
+        args_list = generate_command_args(config, args.framework)
+        print(" \\\n".join(args_list))
+    
+    elif args.format == "yaml":
+        if not HAS_YAML:
+            print("❌ 需要安装 PyYAML: pip install pyyaml")
+            return
+        
+        config_dict = {
+            "framework": args.framework,
+            "data": asdict(config.data),
+            "algorithm": asdict(config.algorithm),
+            "parallel": asdict(config.parallel),
+            "rollout": asdict(config.rollout),
+            "trainer": asdict(config.trainer),
+            "feature": asdict(config.feature),
+            "model_path": config.model_path,
+            "ckpts_dir": config.ckpts_dir,
+            "learning_rate": config.learning_rate,
+            "trainer_gpus": config.trainer_gpus,
+            "rollout_gpus": config.rollout_gpus,
+        }
+        print(yaml.dump(config_dict, default_flow_style=False, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/verl-async-dapo/scripts/feature_manager.sh
+++ b/skills/verl-async-dapo/scripts/feature_manager.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# feature_manager.sh - 智能特性管理
+#
+# 特性策略：
+# 1. 用户显式指定特性 → 优先级最高
+# 2. 用户未指定 → 使用默认性能特性（全开）
+# 3. OOM 时 → 自动追加显存特性重试
+# 4. 显存特性默认关闭，仅在 OOM 时开启
+
+set -euo pipefail
+
+# ==========================================
+# 特性定义
+# ==========================================
+
+# 性能特性 - 提升吞吐，默认开启
+PERF_FEATURES_DEFAULT="flash_attn dynamic_batch remove_padding gradient_checkpointing"
+
+# 显存特性 - 节省显存，默认关闭，OOM 时开启
+MEM_FEATURES="offload recompute"
+
+# ==========================================
+# 配置变量
+# ==========================================
+
+# 用户显式指定 (最高优先级)
+USER_FEATURES="${USER_FEATURES:-}"
+
+# OOM 重试计数
+OOM_RETRY_COUNT="${OOM_RETRY_COUNT:-0}"
+
+# ==========================================
+# 核心逻辑：决定最终特性
+# ==========================================
+
+determine_features() {
+    local result=""
+    local mem_features_to_add=""
+    
+    # ==========================================
+    # Step 1: 基础特性来源
+    # ==========================================
+    
+    if [ -n "$USER_FEATURES" ]; then
+        # 用户显式指定：使用用户特性作为基础
+        info "用户显式指定特性: $USER_FEATURES"
+        result=$(echo "$USER_FEATURES" | tr ',' ' ')
+    else
+        # 用户未指定：使用默认性能特性
+        info "使用默认性能特性: $PERF_FEATURES_DEFAULT"
+        result="$PERF_FEATURES_DEFAULT"
+    fi
+    
+    # ==========================================
+    # Step 2: OOM 时追加显存特性
+    # ==========================================
+    
+    if [ "$OOM_RETRY_COUNT" -ge 1 ]; then
+        info "OOM 重试 #$OOM_RETRY_COUNT：追加显存优化特性"
+
+        # 根据 OOM 重试次数，逐步开启显存特性
+        [ "$OOM_RETRY_COUNT" -ge 1 ] && mem_features_to_add="$mem_features_to_add offload"
+        [ "$OOM_RETRY_COUNT" -ge 2 ] && mem_features_to_add="$mem_features_to_add recompute"
+        
+        # 检查是否已包含显存特性，避免重复
+        for feat in $mem_features_to_add; do
+            if ! echo "$result" | grep -qw "$feat"; then
+                result="$result $feat"
+            fi
+        done
+    fi
+    
+    # ==========================================
+    # Step 3: 输出最终特性
+    # ==========================================
+    
+    info "最终特性配置: $result"
+    echo "$result"
+}
+
+# ==========================================
+# OOM 检测
+# ==========================================
+
+check_oom() {
+    local log_file="${1:-/verl/train.log}"
+    
+    # 检查常见的 OOM 错误模式
+    if grep -qiE "out of memory|OOM|CUDA out of memory|NPU out of memory|memory allocation failed" "$log_file" 2>/dev/null; then
+        warn "检测到 OOM 错误！"
+        return 0  # OOM detected
+    fi
+    return 1  # No OOM
+}
+
+# ==========================================
+# 特性转 Hydra 参数
+# ==========================================
+
+features_to_hydra() {
+    local features="$1"
+    local hydra_args=""
+    
+    for feat in $features; do
+        case "$feat" in
+            flash_attn)
+                hydra_args="$hydra_args ++actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=True"
+                hydra_args="$hydra_args ++actor_rollout_ref.ref.megatron.override_transformer_config.use_flash_attn=True"
+                hydra_args="$hydra_args ++critic.megatron.override_transformer_config.use_flash_attn=True"
+                ;;
+            dynamic_batch|dynamic_bsz)
+                hydra_args="$hydra_args actor_rollout_ref.actor.use_dynamic_bsz=True"
+                hydra_args="$hydra_args actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True"
+                hydra_args="$hydra_args actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=True"
+                ;;
+            remove_padding)
+                hydra_args="$hydra_args actor_rollout_ref.model.use_remove_padding=True"
+                ;;
+            gradient_checkpointing|recompute)
+                hydra_args="$hydra_args actor_rollout_ref.model.enable_gradient_checkpointing=True"
+                ;;
+            offload)
+                hydra_args="$hydra_args actor_rollout_ref.actor.megatron.param_offload=True"
+                hydra_args="$hydra_args actor_rollout_ref.actor.megatron.optimizer_offload=True"
+                hydra_args="$hydra_args actor_rollout_ref.actor.megatron.grad_offload=True"
+                ;;
+            prefix_cache|prefix_caching)
+                hydra_args="$hydra_args actor_rollout_ref.rollout.enable_prefix_caching=True"
+                ;;
+            chunked_prefill)
+                hydra_args="$hydra_args actor_rollout_ref.rollout.enable_chunked_prefill=True"
+                ;;
+            vpp2|vpp)
+                warn "VPP2 特性需要额外配置 pipeline_model_parallel_size，暂不支持自动配置"
+                ;;
+            *)
+                warn "未知特性: $feat (已忽略)"
+                ;;
+        esac
+    done
+    
+    echo "$hydra_args"
+}
+
+# ==========================================
+# 打印特性说明
+# ==========================================
+
+print_feature_help() {
+    cat << 'EOF'
+特性管理说明：
+
+【性能特性】默认开启，提升吞吐
+  - flash_attn          Flash Attention 加速
+  - dynamic_batch       动态 Batch Size
+  - remove_padding      Remove Padding 优化
+  - gradient_checkpointing  梯度检查点
+
+【显存特性】默认关闭，OOM 时自动开启
+  - offload             参数/优化器/梯度卸载到 CPU
+  - recompute           重计算节省显存
+
+【可选特性】默认关闭
+  - prefix_cache        Prefix Cache (vLLM 推理加速)
+  - chunked_prefill     Chunked Prefill
+  - vpp2                Virtual Pipeline Parallel
+
+使用方式：
+  export USER_FEATURES="offload,recompute,prefix_cache"
+  bash scripts/run_dapo.sh
+EOF
+}
+
+# ==========================================
+# 主函数
+# ==========================================
+
+main() {
+    local action="${1:-determine}"
+    
+    case "$action" in
+        determine)
+            determine_features
+            ;;
+        check_oom)
+            check_oom "${2:-/verl/train.log}"
+            ;;
+        to_hydra)
+            features_to_hydra "${2:-}"
+            ;;
+        help|--help|-h)
+            print_feature_help
+            ;;
+        *)
+            echo "用法: $0 {determine|check_oom|to_hydra|help}"
+            exit 1
+            ;;
+    esac
+}
+
+# 如果直接执行
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi

--- a/skills/verl-async-dapo/scripts/preflight_check.sh
+++ b/skills/verl-async-dapo/scripts/preflight_check.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# preflight_check.sh - 训练前综合检查
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# ==========================================
+# 解析参数
+# ==========================================
+MODEL_SIZE="8B"
+MODEL_PATH=""
+TRAIN_DATA=""
+VAL_DATA=""
+CONTAINER_NAME=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model-size) MODEL_SIZE="$2"; shift 2 ;;
+        --model) MODEL_PATH="$2"; shift 2 ;;
+        --train) TRAIN_DATA="$2"; shift 2 ;;
+        --val) VAL_DATA="$2"; shift 2 ;;
+        --container) CONTAINER_NAME="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+# ==========================================
+# 开始检查
+# ==========================================
+echo "=========================================="
+echo "训练前综合检查"
+echo "=========================================="
+
+# 1. NPU 检测
+echo ""
+echo "--- NPU 检测 ---"
+if command -v npu-smi &>/dev/null; then
+    NPU_INFO=$(npu-smi info 2>/dev/null || echo "")
+    NPU_COUNT=$(echo "$NPU_INFO" | grep -c "910B\|Ascend 910" || echo "0")
+    
+    if [[ "$NPU_INFO" == *"910B"* ]]; then
+        ok "NPU 类型: A2 (910B), 检测到 ${NPU_COUNT} 张"
+    elif [[ "$NPU_INFO" == *"Ascend 910"* ]]; then
+        ok "NPU 类型: A3, 检测到 ${NPU_COUNT} 张"
+    else
+        warn "无法检测 NPU 类型"
+    fi
+else
+    warn "npu-smi 不可用，跳过 NPU 检测"
+fi
+
+# 2. 路径验证
+echo ""
+if [ -z "$MODEL_PATH" ]; then
+    case "$MODEL_SIZE" in
+        0.6B|0.6) MODEL_PATH="$DEFAULT_MODEL_06B" ;;
+        *)        MODEL_PATH="$DEFAULT_MODEL_8B" ;;
+    esac
+fi
+[ -z "$TRAIN_DATA" ] && TRAIN_DATA="$DEFAULT_TRAIN_DATA"
+[ -z "$VAL_DATA" ] && VAL_DATA="$DEFAULT_VAL_DATA"
+
+validate_all_paths "$MODEL_PATH" "$TRAIN_DATA" "$VAL_DATA"
+PATH_ERRORS=$?
+
+# 3. Docker 检查
+echo ""
+echo "--- Docker 检查 ---"
+if command -v docker &>/dev/null; then
+    # 查找 verl 容器
+    CONTAINERS=$(docker ps --format "{{.Names}}" 2>/dev/null | grep -E "verl|jins" || echo "")
+    
+    if [ -n "$CONTAINER_NAME" ]; then
+        if docker ps --format "{{.Names}}" | grep -q "$CONTAINER_NAME"; then
+            ok "指定容器存在: $CONTAINER_NAME"
+        else
+            fail "指定容器不存在: $CONTAINER_NAME"
+        fi
+    elif [ -n "$CONTAINERS" ]; then
+        CONTAINER_COUNT=$(echo "$CONTAINERS" | wc -l)
+        if [ "$CONTAINER_COUNT" -eq 1 ]; then
+            ok "唯一容器: $(echo $CONTAINERS)"
+        else
+            warn "多个容器: $(echo $CONTAINERS | tr '\n' ' ')"
+            info "使用 --container 指定容器"
+        fi
+    else
+        warn "未找到 verl 容器，需要创建"
+    fi
+else
+    warn "Docker 不可用"
+fi
+
+# ==========================================
+# 结果
+# ==========================================
+echo ""
+echo "=========================================="
+if [ "$PATH_ERRORS" -eq 0 ]; then
+    ok "所有检查通过! 可以启动训练"
+else
+    fail "有 ${PATH_ERRORS} 个路径错误，请检查后重试"
+fi
+echo "=========================================="

--- a/skills/verl-async-dapo/scripts/quick_start.sh
+++ b/skills/verl-async-dapo/scripts/quick_start.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# quick_start.sh - 快速启动 DAPO 训练
+#
+# 用法:
+#   CONTAINER=jins TRAIN_STEPS=100 bash quick_start.sh
+#
+# 环境变量:
+#   CONTAINER      - 容器名称 (默认: jins)
+#   TRAIN_STEPS    - 训练步数 (默认: 100)
+#   FEATURES       - 特性列表 (默认: 空则使用默认配置)
+#   SWANLAB_HOST   - SwanLab 地址
+#   SWANLAB_API_KEY - SwanLab API 密钥
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# ==========================================
+# 配置参数
+# ==========================================
+CONTAINER="${CONTAINER:-jins}"
+TRAIN_STEPS="${TRAIN_STEPS:-100}"
+FEATURES="${FEATURES:-}"
+
+# SwanLab
+SWANLAB_HOST="${SWANLAB_HOST:-http://10.143.2.129:8000}"
+SWANLAB_API_KEY="${SWANLAB_API_KEY:-}"
+
+# 路径
+MODEL_PATH="/mnt/public/models/huggface_models/Qwen/Qwen3-8B"
+TRAIN_FILE="/mnt2/wql/data/dapo-math-17k.parquet"
+VAL_FILE="/mnt2/wql/data/aime-2024.parquet"
+
+# 训练参数
+PROJECT_NAME="DAPO-Qwen3-8B-async"
+EXP_NAME="DAPO-Qwen3-8B-async-$(date +%m%d_%H%M)"
+TRAINER_GPUS=4
+ROLLOUT_GPUS=4
+TOTAL_GPUS=$((TRAINER_GPUS + ROLLOUT_GPUS))
+
+# ==========================================
+# 交互式询问（非交互模式跳过）
+# ==========================================
+
+if [ -t 0 ]; then
+    # 终端交互模式
+    echo "=========================================="
+    echo "Verl 异步 DAPO 训练启动"
+    echo "=========================================="
+    
+    # 询问特性
+    if [ -z "$FEATURES" ]; then
+        echo ""
+        echo "是否有自定义特性需求？(直接回车使用默认配置)"
+        echo "  性能特性: flash_attn, dynamic_batch, remove_padding, gradient_checkpointing (默认全开)"
+        echo "  显存特性: offload, recompute (默认关闭)"
+        echo "  可选特性: prefix_cache, chunked_prefill"
+        echo ""
+        read -p "输入特性(逗号分隔): " user_features
+        FEATURES="$user_features"
+    fi
+fi
+
+# ==========================================
+# 启动训练
+# ==========================================
+
+info "在容器 $CONTAINER 中启动训练..."
+
+docker exec "$CONTAINER" bash -c "
+cd /verl
+
+# 环境配置
+export SWANLAB_HOST=$SWANLAB_HOST
+export SWANLAB_API_KEY=$SWANLAB_API_KEY
+export VLLM_ASCEND_ENABLE_NZ=0
+export HCCL_EXEC_TIMEOUT=60000
+export HCCL_CONNECT_TIMEOUT=7200
+
+# 清理旧 Ray
+ray stop --force 2>/dev/null || true
+rm -rf /tmp/ray
+sleep 2
+
+# 启动 Ray (显式声明 GPU)
+ray start --head --num-gpus=$TOTAL_GPUS --dashboard-port=8265 --port=6379 2>&1 | tail -5
+sleep 3
+
+# 验证 Ray
+ray status 2>&1 | head -10
+
+# 提交训练任务
+ray job submit --no-wait --address='http://localhost:8265' \\
+    -- python3 -m recipe.dapo.main_dapo \\
+    data.train_files='$TRAIN_FILE' \\
+    data.val_files='$VAL_FILE' \\
+    data.prompt_key=prompt \\
+    data.truncation=left \\
+    data.max_prompt_length=2048 \\
+    data.max_response_length=8192 \\
+    data.gen_batch_size=24 \\
+    data.train_batch_size=8 \\
+    actor_rollout_ref.rollout.n=4 \\
+    algorithm.adv_estimator=grpo \\
+    algorithm.use_kl_in_reward=False \\
+    algorithm.kl_ctrl.kl_coef=0.0 \\
+    actor_rollout_ref.model.path='$MODEL_PATH' \\
+    actor_rollout_ref.model.use_remove_padding=True \\
+    actor_rollout_ref.model.enable_gradient_checkpointing=True \\
+    actor_rollout_ref.actor.optim.lr=1e-6 \\
+    actor_rollout_ref.actor.optim.lr_warmup_steps=10 \\
+    actor_rollout_ref.actor.optim.weight_decay=0.1 \\
+    actor_rollout_ref.actor.ppo_mini_batch_size=1 \\
+    actor_rollout_ref.actor.fsdp_config.param_offload=True \\
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=True \\
+    actor_rollout_ref.actor.entropy_coeff=0 \\
+    actor_rollout_ref.actor.grad_clip=1.0 \\
+    actor_rollout_ref.actor.ulysses_sequence_parallel_size=4 \\
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.50 \\
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \\
+    actor_rollout_ref.rollout.enable_chunked_prefill=True \\
+    actor_rollout_ref.rollout.temperature=1.0 \\
+    actor_rollout_ref.rollout.top_p=1.0 \\
+    actor_rollout_ref.rollout.top_k=-1 \\
+    actor_rollout_ref.rollout.name=vllm \\
+    actor_rollout_ref.ref.fsdp_config.param_offload=True \\
+    actor_rollout_ref.ref.ulysses_sequence_parallel_size=4 \\
+    reward_model.reward_manager=dapo \\
+    trainer.logger='[\"console\",\"swanlab\"]' \\
+    trainer.project_name='$PROJECT_NAME' \\
+    trainer.experiment_name='$EXP_NAME' \\
+    trainer.n_gpus_per_node=$TOTAL_GPUS \\
+    trainer.nnodes=1 \\
+    trainer.val_before_train=False \\
+    trainer.test_freq=20 \\
+    trainer.save_freq=50 \\
+    trainer.total_epochs=1 \\
+    trainer.total_training_steps=$TRAIN_STEPS \\
+    2>&1
+"
+
+info "=========================================="
+info "训练任务已提交！"
+info "=========================================="
+info "SwanLab: $SWANLAB_HOST/@TrainingMaster/$PROJECT_NAME"
+info "Ray Dashboard: http://<container-ip>:8265"
+info "=========================================="

--- a/skills/verl-async-dapo/scripts/run_dapo.sh
+++ b/skills/verl-async-dapo/scripts/run_dapo.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# run_dapo.sh - Verl 异步 DAPO 训练启动脚本
+#
+# 特性管理策略：
+# 1. 用户未指定 → 使用默认性能特性（全开）
+# 2. 用户显式指定 → 优先级最高
+# 3. OOM 时 → 自动追加显存特性重试（即使指定了特性也允许追加）
+#
+# 监控策略：
+# - 启动后输出 SwanLab 链接
+# - 后台静默运行
+# - 仅在错误时通知用户
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/common.sh"
+source "$SCRIPT_DIR/feature_manager.sh"
+
+cd /verl
+
+# ==========================================
+# 配置参数
+# ==========================================
+FRAMEWORK="${FRAMEWORK:-megatron}"
+MODEL_PATH="${MODEL_PATH:-$DEFAULT_MODEL_8B}"
+TRAIN_FILE="${TRAIN_FILE:-$DEFAULT_TRAIN_DATA}"
+VAL_FILE="${VAL_FILE:-$DEFAULT_VAL_DATA}"
+TRAIN_STEPS="${TRAIN_STEPS:-100}"
+EXP_NAME="${EXP_NAME:-DAPO-Qwen3-8b-${FRAMEWORK}-async-$(date +%m%d_%H%M)}"
+PROJECT_NAME="${PROJECT_NAME:-$DEFAULT_PROJECT_NAME}"
+CKPTS_DIR="${CKPTS_DIR:-/mnt2/jins_ckpt/${EXP_NAME}}"
+LEARNING_RATE="${LEARNING_RATE:-1e-6}"
+TRAINER_GPUS="${TRAINER_GPUS:-4}"
+ROLLOUT_GPUS="${ROLLOUT_GPUS:-4}"
+
+# SwanLab 配置（从环境变量或配置文件加载）
+SWANLAB_USER="${SWANLAB_USER:-TrainingMaster}"
+
+# 用户显式指定特性 (可选)
+USER_FEATURES="${USER_FEATURES:-}"
+
+# 最大 OOM 重试次数
+MAX_OOM_RETRIES="${MAX_OOM_RETRIES:-2}"
+
+# ==========================================
+# 路径验证
+# ==========================================
+info "验证路径..."
+validate_all_paths "$MODEL_PATH" "$TRAIN_FILE" "$VAL_FILE"
+if [ $? -gt 0 ]; then
+    fail "路径验证失败，请检查后重试"
+    exit 1
+fi
+
+# ==========================================
+# 环境准备
+# ==========================================
+cleanup_ray
+load_proxy_config
+setup_proxy
+
+# 初始化 SwanLab 配置（从环境变量或配置文件加载）
+init_swanlab_config
+
+# 启动 Ray 集群（NPU 环境需显式声明 GPU 数）
+TOTAL_GPUS=$((TRAINER_GPUS + ROLLOUT_GPUS))
+start_ray_head $TOTAL_GPUS 8265 || exit 1
+
+export VLLM_ASCEND_ENABLE_NZ=0
+export HCCL_EXEC_TIMEOUT=60000
+export HCCL_CONNECT_TIMEOUT=7200
+
+# ==========================================
+# 训练执行函数
+# ==========================================
+
+run_training() {
+    local features="$1"
+    local log_file="${2:-/verl/train.log}"
+
+    # 清空日志
+    : > "$log_file"
+
+    # 生成训练脚本
+    python3 "$SCRIPT_DIR/config_generator.py" \
+        --framework "$FRAMEWORK" \
+        --model "$MODEL_PATH" \
+        --train-data "$TRAIN_FILE" \
+        --val-data "$VAL_FILE" \
+        --steps "$TRAIN_STEPS" \
+        --exp-name "$EXP_NAME" \
+        --project "$PROJECT_NAME" \
+        --ckpt-dir "$CKPTS_DIR" \
+        --lr "$LEARNING_RATE" \
+        --trainer-gpus "$TRAINER_GPUS" \
+        --rollout-gpus "$ROLLOUT_GPUS" \
+        --feature $features \
+        --output /tmp/run_verl_temp.sh
+
+    # 执行训练 (后台)
+    nohup bash /tmp/run_verl_temp.sh >> "$log_file" 2>&1 &
+    local train_pid=$!
+
+    echo "$train_pid" > /verl/train.pid
+
+    # 通过 stdout 输出 PID（供调用方捕获）
+    echo "$train_pid"
+}
+
+# ==========================================
+# 输出 SwanLab 链接
+# ==========================================
+
+print_swanlab_links() {
+    echo ""
+    echo "=========================================="
+    echo "训练已启动！"
+    echo "=========================================="
+    echo ""
+    echo "SwanLab 监控:"
+    echo "  Project: ${SWANLAB_HOST}/@${SWANLAB_USER}/${PROJECT_NAME}"
+    echo "  Run:     ${SWANLAB_HOST}/@${SWANLAB_USER}/${PROJECT_NAME}/runs/${EXP_NAME}"
+    echo ""
+    echo "查看日志:"
+    echo "  docker exec {container} tail -f /verl/train.log"
+    echo ""
+    echo "检查状态:"
+    echo "  docker exec {container} grep 'Training Progress' /verl/train.log | tail -1"
+    echo ""
+    echo "=========================================="
+    echo "训练将在后台静默运行，仅在错误时通知您。"
+    echo "=========================================="
+}
+
+# ==========================================
+# 错误监控函数
+# ==========================================
+
+monitor_for_errors() {
+    local log_file="/verl/train.log"
+    local pid_file="/verl/train.pid"
+    
+    while true; do
+        sleep 30
+        
+        # 检查进程是否还在运行
+        if [ -f "$pid_file" ]; then
+            local pid=$(cat "$pid_file")
+            if ! kill -0 $pid 2>/dev/null; then
+                # 进程已退出，检查是否成功
+                if grep -q "Training completed successfully" "$log_file" 2>/dev/null; then
+                    echo "[INFO] 训练成功完成！"
+                    echo "[INFO] Checkpoint: $CKPTS_DIR"
+                    return 0
+                else
+                    # 训练失败
+                    echo "[ERROR] 训练异常退出！"
+                    echo "[ERROR] 查看日志: tail -50 $log_file"
+                    tail -50 "$log_file"
+                    return 1
+                fi
+            fi
+        fi
+        
+        # 检查是否有 OOM
+        if check_oom "$log_file"; then
+            echo "[ERROR] 检测到 OOM 错误！"
+            return 2  # OOM 特殊退出码
+        fi
+    done
+}
+
+# ==========================================
+# OOM 自动重试主循环
+# ==========================================
+
+main() {
+    local oom_retry=0
+    
+    while true; do
+        # 设置 OOM 重试计数 (供 feature_manager 使用)
+        export OOM_RETRY_COUNT=$oom_retry
+        
+        # 确定特性配置
+        FEATURES=$(determine_features)
+        
+        # 显示启动信息
+        info "=========================================="
+        info "启动 Verl 异步 DAPO 训练"
+        info "=========================================="
+        info "框架: $FRAMEWORK"
+        info "项目: $PROJECT_NAME / 实验: $EXP_NAME"
+        info "步数: $TRAIN_STEPS"
+        info "资源: trainer=$TRAINER_GPUS GPUs, rollout=$ROLLOUT_GPUS GPUs"
+        info "特性: $FEATURES"
+        info "=========================================="
+        
+        # 运行训练（通过 echo 捕获 PID）
+        local train_pid
+        train_pid=$(run_training "$FEATURES" "/verl/train.log")
+        
+        # 输出 SwanLab 链接
+        print_swanlab_links
+        
+        # 监控错误
+        monitor_for_errors
+        local monitor_result=$?
+        
+        # 训练成功
+        if [ $monitor_result -eq 0 ]; then
+            return 0
+        fi
+        
+        # OOM 错误
+        if [ $monitor_result -eq 2 ]; then
+            oom_retry=$((oom_retry + 1))
+            
+            if [ $oom_retry -le $MAX_OOM_RETRIES ]; then
+                warn "[OOM] 尝试追加显存优化特性重试..."
+                warn "[OOM] 重试 $oom_retry / $MAX_OOM_RETRIES"
+                
+                # 清理环境
+                cleanup_ray
+                sleep 10
+            else
+                fail "[OOM] 已达到最大重试次数 ($MAX_OOM_RETRIES)"
+                fail "[OOM] 建议: 减小 batch size 或使用更小模型"
+                return 1
+            fi
+        else
+            # 其他错误
+            return 1
+        fi
+    done
+}
+
+# ==========================================
+# 入口
+# ==========================================
+
+main

--- a/skills/verl-async-dapo/scripts/run_one_step_off_policy.sh
+++ b/skills/verl-async-dapo/scripts/run_one_step_off_policy.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# run_one_step_off_policy.sh - Verl One-Step-Off-Policy DAPO 训练启动脚本
+#
+# 特性：
+# - Trainer 和 Rollout 资源隔离
+# - 支持 Megatron/FSDP2 框架
+# - 自动包含所有必需的 reward_model 配置
+#
+# 用法：
+#   TRAIN_STEPS=100 bash run_one_step_off_policy.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+source "$SCRIPT_DIR/common.sh"
+
+cd /verl
+
+# ==========================================
+# 配置参数
+# ==========================================
+FRAMEWORK="${FRAMEWORK:-megatron}"
+MODEL_PATH="${MODEL_PATH:-$DEFAULT_MODEL_8B}"
+TRAIN_FILE="${TRAIN_FILE:-$DEFAULT_TRAIN_DATA}"
+VAL_FILE="${VAL_FILE:-$DEFAULT_VAL_DATA}"
+TRAIN_STEPS="${TRAIN_STEPS:-100}"
+EXP_NAME="${EXP_NAME:-DAPO-Qwen3-8b-one-step-off-${FRAMEWORK}-$(date +%m%d_%H%M)}"
+PROJECT_NAME="${PROJECT_NAME:-DAPO}"
+CKPTS_DIR="${CKPTS_DIR:-/mnt2/ckpt/${EXP_NAME}}"
+LEARNING_RATE="${LEARNING_RATE:-1e-6}"
+TRAINER_GPUS="${TRAINER_GPUS:-4}"
+ROLLOUT_GPUS="${ROLLOUT_GPUS:-4}"
+
+# 长度参数
+MAX_PROMPT_LENGTH="${MAX_PROMPT_LENGTH:-2048}"
+MAX_RESPONSE_LENGTH="${MAX_RESPONSE_LENGTH:-8192}"
+
+# Batch 参数
+TRAIN_BATCH_SIZE="${TRAIN_BATCH_SIZE:-8}"
+N_RESP_PER_PROMPT="${N_RESP_PER_PROMPT:-4}"
+PPO_MINI_BATCH_SIZE="${PPO_MINI_BATCH_SIZE:-8}"
+PPO_MICRO_BATCH_SIZE="${PPO_MICRO_BATCH_SIZE:-2}"
+
+# 并行参数
+GEN_TP="${GEN_TP:-4}"
+TRAIN_TP="${TRAIN_TP:-4}"
+TRAIN_PP="${TRAIN_PP:-1}"
+
+# 特性开关
+USE_REMOVE_PADDING="${USE_REMOVE_PADDING:-True}"
+ENABLE_GRADIENT_CHECKPOINTING="${ENABLE_GRADIENT_CHECKPOINTING:-True}"
+ENABLE_OFFLOAD="${ENABLE_OFFLOAD:-False}"
+
+# ==========================================
+# 路径验证
+# ==========================================
+info "验证路径..."
+validate_all_paths "$MODEL_PATH" "$TRAIN_FILE" "$VAL_FILE"
+if [ $? -gt 0 ]; then
+    fail "路径验证失败，请检查后重试"
+    exit 1
+fi
+
+# ==========================================
+# 环境准备
+# ==========================================
+cleanup_ray
+load_proxy_config
+setup_proxy
+
+export VLLM_ASCEND_ENABLE_NZ=0
+export HCCL_EXEC_TIMEOUT=60000
+export HCCL_CONNECT_TIMEOUT=7200
+
+# ==========================================
+# 启动训练
+# ==========================================
+info "=========================================="
+info "启动 Verl One-Step-Off-Policy DAPO 训练"
+info "=========================================="
+info "框架: $FRAMEWORK"
+info "项目: $PROJECT_NAME / 实验: $EXP_NAME"
+info "步数: $TRAIN_STEPS"
+info "资源: Trainer=$TRAINER_GPUS GPUs, Rollout=$ROLLOUT_GPUS GPUs"
+info "模型: $MODEL_PATH"
+info "=========================================="
+
+if [ "$FRAMEWORK" = "megatron" ]; then
+    python3 -m recipe.one_step_off_policy.main_ppo \
+        --config-path=config \
+        --config-name='one_step_off_ppo_megatron_trainer.yaml' \
+        data.train_files="${TRAIN_FILE}" \
+        data.val_files="${VAL_FILE}" \
+        data.prompt_key=prompt \
+        data.truncation='left' \
+        data.max_prompt_length=${MAX_PROMPT_LENGTH} \
+        data.max_response_length=${MAX_RESPONSE_LENGTH} \
+        data.train_batch_size=${TRAIN_BATCH_SIZE} \
+        actor_rollout_ref.rollout.n=${N_RESP_PER_PROMPT} \
+        algorithm.adv_estimator=grpo \
+        algorithm.use_kl_in_reward=False \
+        algorithm.kl_ctrl.kl_coef=0.0 \
+        actor_rollout_ref.actor.strategy=megatron \
+        critic.strategy=megatron \
+        actor_rollout_ref.hybrid_engine=False \
+        actor_rollout_ref.model.path="${MODEL_PATH}" \
+        actor_rollout_ref.model.use_remove_padding=${USE_REMOVE_PADDING} \
+        actor_rollout_ref.model.enable_gradient_checkpointing=${ENABLE_GRADIENT_CHECKPOINTING} \
+        actor_rollout_ref.actor.optim.lr=${LEARNING_RATE} \
+        actor_rollout_ref.actor.optim.lr_warmup_steps=10 \
+        actor_rollout_ref.actor.optim.weight_decay=0.1 \
+        actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE} \
+        actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${PPO_MICRO_BATCH_SIZE} \
+        actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${TRAIN_TP} \
+        actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${TRAIN_PP} \
+        actor_rollout_ref.actor.megatron.param_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.actor.megatron.optimizer_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.actor.megatron.grad_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.actor.entropy_coeff=0 \
+        actor_rollout_ref.actor.optim.clip_grad=1.0 \
+        actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=4 \
+        actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${TRAIN_TP} \
+        actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${TRAIN_PP} \
+        actor_rollout_ref.ref.megatron.param_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.rollout.gpu_memory_utilization=0.80 \
+        actor_rollout_ref.rollout.tensor_model_parallel_size=${GEN_TP} \
+        actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=4 \
+        actor_rollout_ref.rollout.enable_chunked_prefill=True \
+        actor_rollout_ref.rollout.max_num_batched_tokens=$((MAX_PROMPT_LENGTH + MAX_RESPONSE_LENGTH)) \
+        actor_rollout_ref.rollout.temperature=1.0 \
+        actor_rollout_ref.rollout.top_p=1.0 \
+        actor_rollout_ref.rollout.top_k=-1 \
+        actor_rollout_ref.rollout.name=vllm \
+        actor_rollout_ref.rollout.mode=async \
+        actor_rollout_ref.nccl_timeout=7200 \
+        reward_model.reward_manager=dapo \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.enable=True \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.len=${MAX_RESPONSE_LENGTH} \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=1.0 \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
+        +reward_model.reward_kwargs.max_resp_len=${MAX_RESPONSE_LENGTH} \
+        trainer.logger='["console"]' \
+        trainer.project_name="${PROJECT_NAME}" \
+        trainer.experiment_name="${EXP_NAME}" \
+        trainer.val_before_train=False \
+        trainer.test_freq=20 \
+        trainer.save_freq=50 \
+        trainer.total_epochs=10 \
+        trainer.total_training_steps=${TRAIN_STEPS} \
+        trainer.default_local_dir="${CKPTS_DIR}" \
+        trainer.resume_mode=auto \
+        trainer.nnodes=1 \
+        trainer.n_gpus_per_node=${TRAINER_GPUS} \
+        rollout.nnodes=1 \
+        rollout.n_gpus_per_node=${ROLLOUT_GPUS} \
+        "$@"
+else
+    # FSDP2 框架
+    python3 -m recipe.one_step_off_policy.main_ppo \
+        --config-path=config \
+        --config-name='one_step_off_ppo_trainer.yaml' \
+        data.train_files="${TRAIN_FILE}" \
+        data.val_files="${VAL_FILE}" \
+        data.prompt_key=prompt \
+        data.truncation='left' \
+        data.max_prompt_length=${MAX_PROMPT_LENGTH} \
+        data.max_response_length=${MAX_RESPONSE_LENGTH} \
+        data.train_batch_size=${TRAIN_BATCH_SIZE} \
+        actor_rollout_ref.rollout.n=${N_RESP_PER_PROMPT} \
+        algorithm.adv_estimator=grpo \
+        algorithm.use_kl_in_reward=False \
+        algorithm.kl_ctrl.kl_coef=0.0 \
+        actor_rollout_ref.actor.strategy=fsdp2 \
+        critic.strategy=fsdp2 \
+        actor_rollout_ref.hybrid_engine=False \
+        actor_rollout_ref.model.path="${MODEL_PATH}" \
+        actor_rollout_ref.model.use_remove_padding=True \
+        actor_rollout_ref.model.enable_gradient_checkpointing=${ENABLE_GRADIENT_CHECKPOINTING} \
+        actor_rollout_ref.actor.optim.lr=${LEARNING_RATE} \
+        actor_rollout_ref.actor.optim.weight_decay=0.1 \
+        actor_rollout_ref.actor.ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE} \
+        actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=${PPO_MICRO_BATCH_SIZE} \
+        actor_rollout_ref.actor.entropy_coeff=0 \
+        actor_rollout_ref.actor.fsdp_config.param_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.actor.fsdp_config.optimizer_offload=${ENABLE_OFFLOAD} \
+        actor_rollout_ref.rollout.gpu_memory_utilization=0.80 \
+        actor_rollout_ref.rollout.tensor_model_parallel_size=${GEN_TP} \
+        actor_rollout_ref.rollout.temperature=1.0 \
+        actor_rollout_ref.rollout.top_p=1.0 \
+        actor_rollout_ref.rollout.name=vllm \
+        actor_rollout_ref.rollout.mode=async \
+        reward_model.reward_manager=dapo \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.enable=True \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.len=${MAX_RESPONSE_LENGTH} \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.penalty_factor=1.0 \
+        +reward_model.reward_kwargs.overlong_buffer_cfg.log=False \
+        +reward_model.reward_kwargs.max_resp_len=${MAX_RESPONSE_LENGTH} \
+        trainer.logger='["console"]' \
+        trainer.project_name="${PROJECT_NAME}" \
+        trainer.experiment_name="${EXP_NAME}" \
+        trainer.val_before_train=False \
+        trainer.test_freq=20 \
+        trainer.save_freq=50 \
+        trainer.total_epochs=10 \
+        trainer.total_training_steps=${TRAIN_STEPS} \
+        trainer.default_local_dir="${CKPTS_DIR}" \
+        trainer.nnodes=1 \
+        trainer.n_gpus_per_node=${TRAINER_GPUS} \
+        rollout.nnodes=1 \
+        rollout.n_gpus_per_node=${ROLLOUT_GPUS} \
+        "$@"
+fi
+
+echo "Training completed successfully!"


### PR DESCRIPTION
## Summary

- **verl-async-dapo**: verl 单异步 DAPO 训练配置生成器，支持启动训练、特性管理、SwanLab 监控
- **swanlab-setup**: SwanLab 实验追踪平台配置管理，支持环境变量/配置文件/交互式输入

## Files

### verl-async-dapo
- `SKILL.md` - 技能说明文档
- `scripts/` - 训练脚本（run_dapo.sh, run_one_step_off_policy.sh 等）
- `references/` - 参数说明、故障排查等参考文档

### swanlab-setup
- `SKILL.md` - 技能说明文档
- `scripts/` - SwanLab 配置管理函数库

## Test plan

- [x] verl-async-dapo 训练脚本可正常执行
- [x] swanlab-setup 可正确配置 SwanLab 凭据

🤖 Generated with [Claude Code](https://claude.com/claude-code)