### PR TITLE
style: Remove install reminder callout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -119,12 +119,6 @@ npx skills add ascend-ai-coding/awesome-ascend-skills -s npu-smi</code></pre>
           <div class="segmented" id="categoryFilters" aria-label="按 Skill 方向筛选"></div>
         </div>
 
-        <div class="install-callout">
-          <strong>下载入口在下方生成</strong>
-          <span>先在左侧勾选一个或多个 Skill，页面会自动在“批量安装命令”区域生成 npx、skills.sh 和 Agent 安装说明。</span>
-          <a class="small-copy" href="#install">查看安装命令</a>
-        </div>
-
         <div class="workspace">
           <aside class="skill-list-panel" aria-label="Skill 列表">
             <div class="list-meta">

--- a/web/styles.css
+++ b/web/styles.css
@@ -382,32 +382,6 @@ code {
   color: var(--color-secondary);
 }
 
-.install-callout {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  margin: 0 0 16px;
-  padding: 13px 14px;
-  border: 1px solid #bfdbfe;
-  border-radius: var(--radius);
-  background: #eff6ff;
-}
-
-.install-callout strong {
-  flex: 0 0 auto;
-  color: #1e3a8a;
-}
-
-.install-callout span {
-  min-width: 0;
-  color: #334155;
-}
-
-.install-callout .small-copy {
-  flex: 0 0 auto;
-  margin-left: auto;
-}
-
 .search-box {
   display: flex;
   align-items: center;
@@ -1087,15 +1061,6 @@ code {
   .section-heading {
     align-items: start;
     flex-direction: column;
-  }
-
-  .install-callout {
-    align-items: flex-start;
-    flex-direction: column;
-  }
-
-  .install-callout .small-copy {
-    margin-left: 0;
   }
 
   .terminal-panel pre,


### PR DESCRIPTION
## 变更描述

### 变更类型
- [ ] 新增 Skill
- [ ] 更新现有 Skill
- [ ] 修复问题
- [x] 其他（请说明）：网页索引 UI 精简

### 涉及的 Skill
Skill 名称：N/A

### 变更内容摘要
删除 Skill 索引页中“下载入口在下方生成”的提示栏，避免在筛选区和批量安装命令区之间重复提醒。
同步移除不再使用的 `.install-callout` 样式和移动端规则。

---

## 检查清单

### 治理规则检查
- [x] 已阅读 `docs/governance/skill-governance.md`
- [x] 已明确本次变更不新增或修改具体 Skill 功能域
- [x] 已明确本次变更属于网页索引 UI 更新
- [x] 如为本地 skill，目录位于 `skills/<domain>/...`（N/A）
- [x] 如与其他 bundle 或 skill 容易混淆，已补充“怎么选”的边界说明（N/A）

### SKILL.md 格式检查
- [x] 未新增或修改 Skill
- [x] 正文中无新增 `[TODO]` 或 `[TODO:xxx]` 占位符

### 内容完整性检查
- [x] 不再存在 `.install-callout` 相关未使用样式
- [x] 页面主要结构保留搜索、筛选、列表和批量安装命令区域

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`（N/A）
- [x] 已更新 `README.md` 中对应的导航 / 安装入口 / decision tree（N/A）
- [x] 如涉及开发目录导航，已同步更新 `skills/README.md` 或对应 `skills/<domain>/README.md`（N/A）
- [x] 如变更治理规则，已同步更新 `docs/governance/skill-governance.md`（N/A）

---

## 测试说明

### 本地验证

```bash
git diff --check -- web
node --check web/app.js
python3 scripts/validate_skills.py
python3 -m pytest tests/test_sync_external_skills.py
```

验证结果：
- `scripts/validate_skills.py` 通过，保留 3 个既有 warning
- `tests/test_sync_external_skills.py` 通过，17 passed

### 本地测试截图
N/A

### CI 检查
提交 PR 后将自动运行仓库 CI。

---

## 其他说明

#113 已先合入，本 PR 基于最新 `main` 单独提交该 UI 精简改动。

### 关联 Issue
Fixes #

### 截图（如适用）
N/A