### PR TITLE
feat(sync): Support marketplace-aware external sync

### DIFF
--- a/.github/external-sources.yml
+++ b/.github/external-sources.yml
@@ -10,6 +10,8 @@
 #   branch      - 可选：要同步的分支，默认 main
 #   enabled     - 可选：是否启用同步，默认 true
 #   skills_path - 可选：skills 所在的子目录路径，默认为根目录
+#   sync_mode   - 可选：flat 递归扫描 SKILL.md；marketplace 按 marketplace.json 引用同步
+#   marketplace_path - 可选：sync_mode=marketplace 时的 marketplace.json 路径
 
 sources:
   - name: mindstudio                    # MindStudio Profiler 诊断工具集
@@ -21,4 +23,11 @@ sources:
     url: https://gitcode.com/Ascend/agent-skills
     branch: master
     skills_path: skills                 # skills 在 skills/ 子目录下
+    enabled: true
+
+  - name: cannbot                       # CANN Bot marketplace-defined skill bundles
+    url: https://gitcode.com/cann/cannbot-skills
+    branch: master
+    sync_mode: marketplace              # 只同步外部 marketplace.json 引用的 skill
+    marketplace_path: .claude-plugin/marketplace.json
     enabled: true

--- a/docs/governance/skill-governance.md
+++ b/docs/governance/skill-governance.md
@@ -53,8 +53,10 @@
 
 从外部仓库自动同步的 skills。
 
-- 命名规则：`external-<source>-<skill>`
-- 存储路径：`external/{source-name}/{skill-name}/`
+- 命名规则：`external-<source>-<skill>`；如果外部 marketplace 保留了多级相对路径，则使用 `external-<source>-<path-slug>`
+- 存储路径：
+  - flat 同步：`external/{source-name}/{skill-name}/`
+  - marketplace 同步：`external/{source-name}/{upstream-source-path}/{skill-name}/`
 - 设计原则：
   - 不作为默认新手入口
   - 需要与本仓技能明确边界
@@ -125,7 +127,7 @@
 3. 本地 leaf skill 的主分类应与其 `skills/<domain>/...` 路径一致
 4. bundle / domain skill set 可以包含多个能力标签，但不能用能力标签替代主分类
 5. 带 `skills` 数组的 bundle / skill set 必须引用同一个目录树内的 skills；不要在一个 bundle 中混入其他功能域目录
-6. 外部同步 skill group 统一以 `external` 作为主分类，并补充 `external-skill-set`、`external-sync`
+6. 外部同步 skill group 统一以 `external` 作为主分类，并补充 `external-skill-set`、`external-sync`；如果外部仓提供 marketplace bundle，应保留上游 bundle 分组并映射到 `external/<source>/...` 下的真实路径
 
 ## 4. 命名与收敛规则
 
@@ -137,7 +139,7 @@
 - 本地 leaf skill：仍使用原始 leaf 名称，不额外追加分类前缀
 - 本地 nested skill：名称以前一层领域子目录为前缀，不额外追加 `skills-` 这类路径前缀
 - `skills/ai-for-science/` 下的本地 skill：保持 `ai-for-science-*` 语义前缀
-- external skill：保持同步命名，不在本仓重命名
+- external skill：由同步脚本注入 `external-<source>-...` 前缀；flat 同步使用 skill 名，marketplace 同步使用上游相对路径 slug
 
 ### 4.2 何时新建 bundle
 

--- a/scripts/sync_external_skills.py
+++ b/scripts/sync_external_skills.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import posixpath
 import yaml
 from datetime import datetime
 from pathlib import Path
@@ -16,7 +17,8 @@ project_root = script_dir.parent
 sys.path.insert(0, str(project_root))
 sys.path.insert(0, str(script_dir))
 
-from sync_types import ExternalSource, Skill, ConflictInfo, SyncResult
+from sync_types import ExternalBundle, ExternalSource, Skill, ConflictInfo, SyncResult
+from validate_skills import validate_skill_file
 
 
 FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n?", re.DOTALL)
@@ -121,7 +123,13 @@ def load_config(config_path: str) -> List[ExternalSource]:
             url=source_data["url"],
             branch=source_data.get("branch", "main"),
             enabled=source_data.get("enabled", True),
-            skills_path=source_data.get("skills_path", ""),
+            skills_path=source_config_path(
+                source_data.get("skills_path", ""), allow_empty=True
+            ),
+            sync_mode=source_data.get("sync_mode", "flat"),
+            marketplace_path=source_config_path(
+                source_data.get("marketplace_path", ".claude-plugin/marketplace.json")
+            ),
         )
         sources.append(source)
 
@@ -165,6 +173,10 @@ def detect_config_changes(old_config: str, new_config: str) -> List[ExternalSour
                     branch=new_source_data.get("branch", "main"),
                     enabled=new_source_data.get("enabled", True),
                     skills_path=new_source_data.get("skills_path", ""),
+                    sync_mode=new_source_data.get("sync_mode", "flat"),
+                    marketplace_path=new_source_data.get(
+                        "marketplace_path", ".claude-plugin/marketplace.json"
+                    ),
                 )
             )
 
@@ -179,6 +191,11 @@ def detect_config_changes(old_config: str, new_config: str) -> List[ExternalSour
                     url=new_source_data["url"],
                     branch=new_source_data.get("branch", "main"),
                     enabled=new_source_data.get("enabled", True),
+                    skills_path=new_source_data.get("skills_path", ""),
+                    sync_mode=new_source_data.get("sync_mode", "flat"),
+                    marketplace_path=new_source_data.get(
+                        "marketplace_path", ".claude-plugin/marketplace.json"
+                    ),
                 )
             )
 
@@ -343,6 +360,34 @@ def parse_skill_name_from_file(skill_md: Path) -> str:
     return str(parsed.get("name", "")).strip()
 
 
+def normalize_external_rel_path(path: str) -> str:
+    """Normalize a marketplace path and reject paths outside the source root."""
+    normalized = posixpath.normpath(path.strip().replace("\\", "/"))
+    if normalized in {"", "."}:
+        return ""
+    if normalized.startswith("../") or normalized.startswith("/") or normalized == "..":
+        raise ValueError(f"External skill path escapes source root: {path}")
+    return normalized
+
+
+def source_config_path(value: str, *, allow_empty: bool = False) -> str:
+    """Normalize source config paths before joining them to cloned repos."""
+    normalized = normalize_external_rel_path(value)
+    if not normalized and not allow_empty:
+        raise ValueError("Source config path must not be empty")
+    return normalized
+
+
+def external_skill_rel_path(skill: Skill) -> str:
+    """Return the external storage path for a skill under external/<source>/."""
+    return normalize_external_rel_path(skill.relative_path or skill.name)
+
+
+def skill_name_slug(skill: Skill) -> str:
+    """Return a stable slug for the synced skill frontmatter name."""
+    return external_skill_rel_path(skill).replace("/", "-")
+
+
 def find_skills(repo_path: Path, source: ExternalSource) -> List[Skill]:
     """Find all skills (dirs with SKILL.md) in repo.
 
@@ -370,9 +415,83 @@ def find_skills(repo_path: Path, source: ExternalSource) -> List[Skill]:
                 path=skill_dir,
                 source=source,
                 has_skill_md=True,
+                relative_path=skill_dir.name,
             )
         )
     return skills
+
+
+def resolve_marketplace_skill_path(plugin_source: str, skill_source: str) -> str:
+    """Resolve plugin source + skill entry using marketplace path semantics."""
+    plugin_root = normalize_external_rel_path(plugin_source.removeprefix("./"))
+    skill_path = normalize_external_rel_path(skill_source.removeprefix("./"))
+    return normalize_external_rel_path(posixpath.join(plugin_root, skill_path))
+
+
+def discover_marketplace_skills(
+    repo_path: Path, source: ExternalSource
+) -> Tuple[List[Skill], List[ExternalBundle]]:
+    """Discover skills and bundle definitions from an external marketplace.json."""
+    source_root = repo_path / source.skills_path if source.skills_path else repo_path
+    marketplace_file = repo_path / source.marketplace_path
+    if not marketplace_file.exists():
+        return [], []
+
+    marketplace = yaml.safe_load(marketplace_file.read_text(encoding="utf-8")) or {}
+    skills_by_rel_path: Dict[str, Skill] = {}
+    bundles: List[ExternalBundle] = []
+
+    for plugin in marketplace.get("plugins", []):
+        if not isinstance(plugin, dict):
+            continue
+
+        plugin_skills = plugin.get("skills", [])
+        if not isinstance(plugin_skills, list) or not plugin_skills:
+            continue
+
+        plugin_source = str(plugin.get("source", "./"))
+        bundle_skill_paths: List[str] = []
+
+        for raw_skill_source in plugin_skills:
+            if not isinstance(raw_skill_source, str):
+                continue
+
+            rel_path = resolve_marketplace_skill_path(plugin_source, raw_skill_source)
+            skill_dir = source_root / rel_path
+            if not (skill_dir / "SKILL.md").exists():
+                continue
+
+            if rel_path not in skills_by_rel_path:
+                skills_by_rel_path[rel_path] = Skill(
+                    name=skill_dir.name,
+                    path=skill_dir,
+                    source=source,
+                    has_skill_md=True,
+                    relative_path=rel_path,
+                )
+            bundle_skill_paths.append(f"./external/{source.name}/{rel_path}")
+
+        if bundle_skill_paths:
+            bundles.append(
+                ExternalBundle(
+                    name=str(plugin.get("name", f"{source.name}-skills")),
+                    source=source,
+                    description=str(plugin.get("description", "")),
+                    skill_paths=bundle_skill_paths,
+                )
+            )
+
+    skills = [skills_by_rel_path[key] for key in sorted(skills_by_rel_path.keys())]
+    return skills, bundles
+
+
+def discover_source_skills(
+    repo_path: Path, source: ExternalSource
+) -> Tuple[List[Skill], List[ExternalBundle]]:
+    """Discover skills using the configured sync mode for a source."""
+    if source.sync_mode == "marketplace":
+        return discover_marketplace_skills(repo_path, source)
+    return find_skills(repo_path, source), []
 
 
 def get_local_skills() -> Set[str]:
@@ -413,14 +532,14 @@ def load_existing_external_skills(
         if not source_dir.exists() or not source_dir.is_dir():
             continue
 
-        for skill_dir in source_dir.iterdir():
-            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
-                continue
+        for skill_md in sorted(source_dir.rglob("SKILL.md")):
+            skill_dir = skill_md.parent
+            rel_path = skill_dir.relative_to(source_dir).as_posix()
 
             parsed = parse_skill_md(skill_dir)
             commit_sha = str(parsed.get("synced-commit", ""))
             source_url = str(parsed.get("synced-from", source.url))
-            existing_skills[(source_name, skill_dir.name)] = (
+            existing_skills[(source_name, rel_path)] = (
                 Skill(
                     name=skill_dir.name,
                     path=skill_dir,
@@ -430,8 +549,11 @@ def load_existing_external_skills(
                         branch=source.branch,
                         enabled=source.enabled,
                         skills_path=source.skills_path,
+                        sync_mode=source.sync_mode,
+                        marketplace_path=source.marketplace_path,
                     ),
                     has_skill_md=True,
+                    relative_path=rel_path,
                 ),
                 commit_sha,
             )
@@ -443,8 +565,9 @@ def build_synced_skill_index(
     synced_skills: Dict[Tuple[str, str], Tuple[Skill, str]],
 ) -> Dict[str, Set[str]]:
     index: Dict[str, Set[str]] = {}
-    for source_name, skill_name in synced_skills.keys():
-        index.setdefault(skill_name, set()).add(source_name)
+    for source_name, rel_path in synced_skills.keys():
+        skill, _commit = synced_skills[(source_name, rel_path)]
+        index.setdefault(skill.name, set()).add(source_name)
     return index
 
 
@@ -453,11 +576,19 @@ def prune_removed_source_skills(
     source: ExternalSource,
     current_skill_names: Set[str],
 ) -> None:
+    def is_current_path(rel_path: str) -> bool:
+        if source.sync_mode == "marketplace":
+            return any(
+                rel_path == current_path or rel_path.startswith(f"{current_path}/")
+                for current_path in current_skill_names
+            )
+        return rel_path in current_skill_names
+
     source_root = Path("external") / source.name
     removed_keys = [
         key
         for key in existing_skills
-        if key[0] == source.name and key[1] not in current_skill_names
+        if key[0] == source.name and not is_current_path(key[1])
     ]
 
     for key in removed_keys:
@@ -466,8 +597,12 @@ def prune_removed_source_skills(
             shutil.rmtree(skill_path)
         del existing_skills[key]
 
-    if source_root.exists() and not any(source_root.iterdir()):
-        source_root.rmdir()
+    if source_root.exists():
+        for path in sorted(source_root.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+            if path.is_dir() and not any(path.iterdir()):
+                path.rmdir()
+        if not any(source_root.iterdir()):
+            source_root.rmdir()
 
 
 def detect_conflicts(
@@ -508,9 +643,9 @@ def inject_attribution(skill: Skill, commit_sha: str) -> str:
     """
     fm, body = read_skill_md(skill.path)
 
-    # Rename skill to follow nested naming convention: external-{source}-{name}
+    # Rename skill to follow nested naming convention: external-{source}-{path-slug}
     original_name = fm.get("name", skill.name)
-    new_name = f"external-{skill.source.name}-{skill.name}"
+    new_name = f"external-{skill.source.name}-{skill_name_slug(skill)}"
     fm["name"] = new_name
     fm["original-name"] = original_name
 
@@ -555,6 +690,46 @@ def get_validation_failure_reason(output: str) -> str:
     return "Validation failed"
 
 
+def inject_attribution_tree(target: Path, source: ExternalSource, commit_sha: str) -> None:
+    """Inject attribution into every SKILL.md copied under an external skill tree."""
+    source_root = Path("external") / source.name
+    for skill_md in sorted(target.rglob("SKILL.md")):
+        skill_dir = skill_md.parent
+        rel_path = skill_dir.relative_to(source_root).as_posix()
+        copied_skill = Skill(
+            name=skill_dir.name,
+            path=skill_dir,
+            source=source,
+            has_skill_md=True,
+            relative_path=rel_path,
+        )
+        attributed_content = inject_attribution(copied_skill, commit_sha)
+        skill_md.write_text(attributed_content, encoding="utf-8")
+
+
+def validate_copied_skill_tree(target: Path) -> Tuple[bool, str]:
+    """Validate copied SKILL.md files without requiring marketplace to be final yet."""
+    repo_root = Path.cwd().resolve()
+    for skill_md in sorted(target.rglob("SKILL.md")):
+        errors, _warnings = validate_skill_file(skill_md.resolve(), repo_root)
+        if errors:
+            return False, errors[0]
+    return True, ""
+
+
+def ignore_nested_skill_dirs(root_skill_path: Path):
+    """Build a copytree ignore function that skips nested skill directories."""
+
+    def ignore(current_dir: str, names: List[str]) -> Set[str]:
+        ignored = {name for name in names if name == ".git"}
+        current_path = Path(current_dir)
+        if current_path != root_skill_path and "SKILL.md" in names:
+            ignored.update(names)
+        return ignored
+
+    return ignore
+
+
 def copy_skill(skill: Skill, commit_sha: str) -> Tuple[bool, str]:
     """Copy skill to external/ directory, inject attribution, and validate.
 
@@ -565,7 +740,7 @@ def copy_skill(skill: Skill, commit_sha: str) -> Tuple[bool, str]:
     Returns:
         Tuple of (success, reason). Reason is empty on success.
     """
-    target = Path("external") / skill.source.name / skill.name
+    target = Path("external") / skill.source.name / external_skill_rel_path(skill)
     backup_dir: Optional[Path] = None
     backup_target: Optional[Path] = None
     keep_backup = False
@@ -576,18 +751,15 @@ def copy_skill(skill: Skill, commit_sha: str) -> Tuple[bool, str]:
         shutil.move(target, backup_target)
 
     try:
-        shutil.copytree(skill.path, target, ignore=shutil.ignore_patterns(".git"))
+        ignore = shutil.ignore_patterns(".git")
+        if skill.source.sync_mode != "marketplace":
+            ignore = ignore_nested_skill_dirs(skill.path)
 
-        copied_skill = Skill(
-            name=skill.name, path=target, source=skill.source, has_skill_md=True
-        )
-        attributed_content = inject_attribution(copied_skill, commit_sha)
-        (target / "SKILL.md").write_text(attributed_content, encoding="utf-8")
+        shutil.copytree(skill.path, target, ignore=ignore)
 
-        result = subprocess.run(
-            ["python3", "scripts/validate_skills.py"], capture_output=True, text=True
-        )
-        if result.returncode == 0:
+        inject_attribution_tree(target, skill.source, commit_sha)
+        is_valid, validation_reason = validate_copied_skill_tree(target)
+        if is_valid:
             return True, ""
 
         cleanup_copied_skill(target)
@@ -599,8 +771,7 @@ def copy_skill(skill: Skill, commit_sha: str) -> Tuple[bool, str]:
                 False,
                 f"Validation failed and restore did not complete: {restore_exc}",
             )
-        failure_output = result.stdout or result.stderr
-        return False, get_validation_failure_reason(failure_output)
+        return False, validation_reason
     except Exception as exc:
         cleanup_copied_skill(target)
         try:
@@ -737,6 +908,7 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
     all_synced_skills = []  # List of (Skill, commit_sha) tuples
     all_skipped = []
     all_errors = []
+    all_bundles: List[ExternalBundle] = []
 
     for source in sources:
         if not source.enabled:
@@ -750,9 +922,9 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
             repo_path, commit_sha = clone_external_repo(source)
             print(f"  ✓ Cloned to {repo_path} (commit: {commit_sha[:7]})")
 
-            skills = find_skills(repo_path, source)
+            skills, bundles = discover_source_skills(repo_path, source)
             print(f"  Found {len(skills)} skills")
-            current_skill_names = {skill.name for skill in skills}
+            current_skill_names = {external_skill_rel_path(skill) for skill in skills}
             prune_removed_source_skills(
                 existing_external_skills, source, current_skill_names
             )
@@ -779,12 +951,17 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
                         print(f"  ✓ Synced {skill.name}")
                         synced_skill = Skill(
                             name=skill.name,
-                            path=Path("external") / skill.source.name / skill.name,
+                            path=Path("external")
+                            / skill.source.name
+                            / external_skill_rel_path(skill),
                             source=skill.source,
                             has_skill_md=True,
+                            relative_path=external_skill_rel_path(skill),
                         )
                         all_synced_skills.append((synced_skill, commit_sha))
-                        existing_external_skills[(skill.source.name, skill.name)] = (
+                        existing_external_skills[
+                            (skill.source.name, external_skill_rel_path(skill))
+                        ] = (
                             synced_skill,
                             commit_sha,
                         )
@@ -797,6 +974,7 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
 
             shutil.rmtree(repo_path)
             print(f"  ✓ Cleaned up {repo_path}")
+            all_bundles.extend(bundles)
 
         except Exception as e:
             print(f"  ❌ Error processing source {source.name}: {e}")
@@ -809,7 +987,7 @@ def sync_all_sources(config_path: str = ".github/external-sources.yml") -> Dict:
     )
 
     print("\nUpdating marketplace.json...")
-    update_marketplace(merged_synced_skills)
+    update_marketplace(merged_synced_skills, external_bundles=all_bundles)
     print("\nUpdating README.md...")
     update_readme(merged_synced_skills)
     print("\nValidating synced repository...")
@@ -870,7 +1048,10 @@ def update_readme(
         source_link = f"[{source_name}]({source_url})"
 
         # Format skill link
-        skill_link = f"[{skill.name}](external/{source_name}/{skill.name}/SKILL.md)"
+        skill_link = (
+            f"[{skill.name}](external/{source_name}/"
+            f"{external_skill_rel_path(skill)}/SKILL.md)"
+        )
 
         # Clean description for markdown table (escape pipe, remove newlines, truncate)
         clean_description = description.replace("|", "\\|").replace("\n", " ").strip()
@@ -916,9 +1097,34 @@ def update_readme(
     readme_file.write_text(content, encoding="utf-8")
 
 
+def filter_external_bundles(
+    external_bundles: List[ExternalBundle], synced_skills: List[Tuple[Skill, str]]
+) -> List[ExternalBundle]:
+    """Keep only bundle skill paths that exist in the final synced skill set."""
+    existing_paths = {
+        f"./external/{skill.source.name}/{external_skill_rel_path(skill)}"
+        for skill, _ in synced_skills
+    }
+    filtered_bundles = []
+    for bundle in external_bundles:
+        skill_paths = [path for path in bundle.skill_paths if path in existing_paths]
+        if not skill_paths:
+            continue
+        filtered_bundles.append(
+            ExternalBundle(
+                name=bundle.name,
+                source=bundle.source,
+                description=bundle.description,
+                skill_paths=skill_paths,
+            )
+        )
+    return filtered_bundles
+
+
 def update_marketplace(
     synced_skills: List[Tuple[Skill, str]],
     marketplace_path: str = ".claude-plugin/marketplace.json",
+    external_bundles: Optional[List[ExternalBundle]] = None,
 ) -> None:
     """Update marketplace.json with external skills entries grouped by source.
 
@@ -926,7 +1132,8 @@ def update_marketplace(
         synced_skills: List of tuples (Skill, commit_sha) that were successfully synced
         marketplace_path: Path to marketplace.json file (default: .claude-plugin/marketplace.json)
 
-    Groups external skills by source and creates one entry per source with skills array.
+    Groups flat external syncs by source. Marketplace-aware syncs can pass
+    external_bundles to preserve upstream bundle entries.
     """
     import json
     from collections import defaultdict
@@ -965,6 +1172,9 @@ def update_marketplace(
         len(plugins),
     )
 
+    external_bundles = filter_external_bundles(external_bundles or [], synced_skills)
+    bundled_sources = {bundle.source.name for bundle in external_bundles}
+
     # Group skills by source
     skills_by_source: Dict[str, List[Tuple[Skill, str]]] = defaultdict(list)
     for skill, commit_sha in synced_skills:
@@ -976,13 +1186,46 @@ def update_marketplace(
 
     # Create grouped entries for each source
     external_plugins = []
+    for bundle in sorted(
+        external_bundles, key=lambda item: (item.source.name, item.name)
+    ):
+        entry_name = f"external-{bundle.source.name}-{bundle.name}"
+        existing_categories = [
+            category
+            for category in existing_external_categories.get(entry_name, [])
+            if isinstance(category, str)
+        ]
+        categories = list(dict.fromkeys(BASE_EXTERNAL_CATEGORIES + existing_categories))
+        description_text = bundle.description or (
+            f"从 {bundle.source.name} 同步的 {bundle.name} 技能包，"
+            f"包含 {len(bundle.skill_paths)} 个技能"
+        )
+        external_plugins.append(
+            {
+                "name": entry_name,
+                "description": description_text,
+                "source": "./",
+                "strict": False,
+                "external": True,
+                "source-url": bundle.source.url,
+                "source-branch": bundle.source.branch,
+                "upstream-name": bundle.name,
+                "category": "external",
+                "categories": categories,
+                "skills": bundle.skill_paths,
+            }
+        )
+
     for source_name, skills_list in sorted(skills_by_source.items()):
+        if source_name in bundled_sources:
+            continue
+
         source = skills_list[0][0].source
         skill_paths = []
         descriptions = []
 
         for skill, _ in skills_list:
-            skill_paths.append(f"./external/{source_name}/{skill.name}")
+            skill_paths.append(f"./external/{source_name}/{external_skill_rel_path(skill)}")
             parsed = parse_skill_md(skill.path)
             desc = parsed.get("description", "")
             if desc:

--- a/scripts/sync_types.py
+++ b/scripts/sync_types.py
@@ -3,7 +3,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import List, Tuple
 
 
 @dataclass
@@ -16,6 +16,8 @@ class ExternalSource:
         branch: Branch name to clone (default: "main").
         enabled: Whether this source is active (default: True).
         skills_path: Subdirectory path where skills are located (default: "" for root).
+        sync_mode: "flat" scans all SKILL.md files; "marketplace" follows marketplace.json.
+        marketplace_path: Marketplace path relative to the external repository root.
     """
 
     name: str
@@ -23,6 +25,8 @@ class ExternalSource:
     branch: str = "main"
     enabled: bool = True
     skills_path: str = ""
+    sync_mode: str = "flat"
+    marketplace_path: str = ".claude-plugin/marketplace.json"
 
 
 @dataclass
@@ -34,12 +38,24 @@ class Skill:
         path: Absolute path to skill directory.
         source: ExternalSource this skill comes from.
         has_skill_md: Whether SKILL.md file exists.
+        relative_path: Skill path relative to the external source root.
     """
 
     name: str
     path: Path
     source: ExternalSource
     has_skill_md: bool
+    relative_path: str = ""
+
+
+@dataclass
+class ExternalBundle:
+    """Represents a marketplace-defined external skill bundle."""
+
+    name: str
+    source: ExternalSource
+    description: str
+    skill_paths: List[str]
 
 
 @dataclass

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -5,12 +5,25 @@ import sys
 import yaml
 from pathlib import Path
 import re
+import posixpath
 
 
 def validate_url_format(url: str) -> bool:
     """Validate URL format using basic regex."""
     pattern = r"^https?://[^\s/$.?#].[^\s]*$"
     return bool(re.match(pattern, url))
+
+
+def is_safe_relative_path(path: str, *, allow_empty: bool = False) -> bool:
+    """Return whether a config path stays inside the cloned source root."""
+    normalized = posixpath.normpath(path.strip().replace("\\", "/"))
+    if normalized in {"", "."}:
+        return allow_empty
+    return not (
+        normalized == ".."
+        or normalized.startswith("../")
+        or normalized.startswith("/")
+    )
 
 
 def validate_config(config_path: Path) -> int:
@@ -93,6 +106,42 @@ def validate_config(config_path: Path) -> int:
             if not isinstance(enabled, bool):
                 print(
                     f"Validation error: Source at index {i} 'enabled' must be a boolean"
+                )
+                return 1
+
+        if "skills_path" in source and not isinstance(source["skills_path"], str):
+            print(
+                f"Validation error: Source at index {i} 'skills_path' must be a string"
+            )
+            return 1
+        if "skills_path" in source and not is_safe_relative_path(
+            source["skills_path"], allow_empty=True
+        ):
+            print(
+                f"Validation error: Source at index {i} 'skills_path' must be a safe relative path"
+            )
+            return 1
+
+        if "marketplace_path" in source and not isinstance(
+            source["marketplace_path"], str
+        ):
+            print(
+                f"Validation error: Source at index {i} 'marketplace_path' must be a string"
+            )
+            return 1
+        if "marketplace_path" in source and not is_safe_relative_path(
+            source["marketplace_path"]
+        ):
+            print(
+                f"Validation error: Source at index {i} 'marketplace_path' must be a safe relative path"
+            )
+            return 1
+
+        if "sync_mode" in source:
+            sync_mode = source["sync_mode"]
+            if sync_mode not in {"flat", "marketplace"}:
+                print(
+                    f"Validation error: Source at index {i} 'sync_mode' must be 'flat' or 'marketplace'"
                 )
                 return 1
 

--- a/tests/test_sync_external_skills.py
+++ b/tests/test_sync_external_skills.py
@@ -3,10 +3,11 @@
 import json
 import os
 from pathlib import Path
-from types import SimpleNamespace
 
+from scripts.validate_config import validate_config
 from scripts import sync_external_skills as sync_module
 from scripts.sync_external_skills import (
+    discover_source_skills,
     build_synced_skill_index,
     copy_skill,
     detect_conflicts,
@@ -17,7 +18,7 @@ from scripts.sync_external_skills import (
     prune_removed_source_skills,
     update_marketplace,
 )
-from scripts.sync_types import ExternalSource, Skill
+from scripts.sync_types import ExternalBundle, ExternalSource, Skill
 
 
 def write_skill(skill_dir: Path, name: str, commit_sha: str = "abc123") -> None:
@@ -174,6 +175,39 @@ def test_prune_removed_source_skills_removes_stale_same_source_entries(
     assert not stale_dir.exists()
 
 
+def test_prune_removed_source_skills_keeps_marketplace_nested_children(
+    tmp_path: Path,
+) -> None:
+    source = ExternalSource(
+        name="source-a",
+        url="https://example.com/a.git",
+        sync_mode="marketplace",
+    )
+    parent_dir = tmp_path / "external" / "source-a" / "ops" / "parent-skill"
+    child_dir = parent_dir / "child-skill"
+    stale_dir = tmp_path / "external" / "source-a" / "ops" / "stale-skill"
+    write_skill(parent_dir, "external-source-a-ops-parent-skill")
+    write_skill(child_dir, "external-source-a-ops-parent-skill-child-skill")
+    write_skill(stale_dir, "external-source-a-ops-stale-skill")
+
+    existing = load_existing_external_skills(
+        [source], external_root=tmp_path / "external"
+    )
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        prune_removed_source_skills(existing, source, {"ops/parent-skill"})
+    finally:
+        os.chdir(original_cwd)
+
+    assert ("source-a", "ops/parent-skill") in existing
+    assert ("source-a", "ops/parent-skill/child-skill") in existing
+    assert ("source-a", "ops/stale-skill") not in existing
+    assert child_dir.exists()
+    assert not stale_dir.exists()
+
+
 def test_parse_skill_md_falls_back_for_colon_rich_description(tmp_path: Path) -> None:
     skill_dir = tmp_path / "ascendc-operator-code-gen"
     write_raw_skill(
@@ -310,6 +344,68 @@ def test_find_skills_recurses_under_configured_skills_path(tmp_path: Path) -> No
     skills = find_skills(repo, source)
 
     assert {skill.name for skill in skills} == {"npu-smi", "mindspeed-llm-training"}
+    assert {skill.relative_path for skill in skills} == {
+        "npu-smi",
+        "mindspeed-llm-training",
+    }
+
+
+def test_discover_source_skills_uses_external_marketplace_refs(
+    tmp_path: Path,
+) -> None:
+    source = ExternalSource(
+        name="cannbot",
+        url="https://gitcode.com/cann/cannbot-skills",
+        branch="master",
+        sync_mode="marketplace",
+    )
+    repo = tmp_path / "repo"
+    marketplace_dir = repo / ".claude-plugin"
+    marketplace_dir.mkdir(parents=True)
+    (marketplace_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "plugins": [
+                    {
+                        "name": "ops-direct-invoke-skills",
+                        "source": "./ops",
+                        "skills": [
+                            "./ascendc-code-review",
+                            "./nested/ascendc-runtime-debug",
+                        ],
+                        "category": "skills",
+                        "strict": False,
+                    },
+                    {
+                        "name": "plugin-only",
+                        "source": "./plugins-official/plugin-only",
+                        "category": "development",
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    write_skill(repo / "ops" / "ascendc-code-review", "ascendc-code-review")
+    write_skill(
+        repo / "ops" / "nested" / "ascendc-runtime-debug",
+        "ascendc-runtime-debug",
+    )
+    write_skill(repo / "ops" / "not-in-marketplace", "not-in-marketplace")
+
+    skills, bundles = discover_source_skills(repo, source)
+
+    assert [(skill.name, skill.relative_path) for skill in skills] == [
+        ("ascendc-code-review", "ops/ascendc-code-review"),
+        ("ascendc-runtime-debug", "ops/nested/ascendc-runtime-debug"),
+    ]
+    assert len(bundles) == 1
+    assert bundles[0].name == "ops-direct-invoke-skills"
+    assert bundles[0].skill_paths == [
+        "./external/cannbot/ops/ascendc-code-review",
+        "./external/cannbot/ops/nested/ascendc-runtime-debug",
+    ]
 
 
 def test_copy_skill_rolls_back_failed_validation(tmp_path: Path, monkeypatch) -> None:
@@ -318,14 +414,11 @@ def test_copy_skill_rolls_back_failed_validation(tmp_path: Path, monkeypatch) ->
     write_skill(skill_dir, "broken-skill")
     skill = Skill(name="broken-skill", path=skill_dir, source=source, has_skill_md=True)
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(
-            returncode=1,
-            stdout="  ❌ ERROR: Missing 'description' field in frontmatter\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(sync_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sync_module,
+        "validate_copied_skill_tree",
+        lambda target: (False, "Missing 'description' field in frontmatter"),
+    )
 
     original_cwd = Path.cwd()
     try:
@@ -364,14 +457,11 @@ def test_copy_skill_restores_existing_target_on_failed_validation(
         name="broken-skill", path=updated_dir, source=source, has_skill_md=True
     )
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(
-            returncode=1,
-            stdout="  ❌ ERROR: Missing 'description' field in frontmatter\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(sync_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sync_module,
+        "validate_copied_skill_tree",
+        lambda target: (False, "Missing 'description' field in frontmatter"),
+    )
 
     original_cwd = Path.cwd()
     try:
@@ -401,13 +491,6 @@ def test_copy_skill_keeps_backup_when_restore_fails(
 
     backup_dir = tmp_path / "backup-dir"
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(
-            returncode=1,
-            stdout="  ❌ ERROR: Missing 'description' field in frontmatter\n",
-            stderr="",
-        )
-
     real_move = sync_module.shutil.move
 
     def fake_move(src, dst, *args, **kwargs):
@@ -416,7 +499,11 @@ def test_copy_skill_keeps_backup_when_restore_fails(
             raise OSError("restore failed")
         return real_move(src, dst, *args, **kwargs)
 
-    monkeypatch.setattr(sync_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sync_module,
+        "validate_copied_skill_tree",
+        lambda target: (False, "Missing 'description' field in frontmatter"),
+    )
     monkeypatch.setattr(sync_module.tempfile, "mkdtemp", lambda prefix: str(backup_dir))
     monkeypatch.setattr(sync_module.shutil, "move", fake_move)
 
@@ -453,10 +540,9 @@ def test_copy_skill_syncs_malformed_frontmatter_when_validation_passes(
     )
     skill = Skill(name="broken-skill", path=skill_dir, source=source, has_skill_md=True)
 
-    def fake_run(*args, **kwargs):
-        return SimpleNamespace(returncode=0, stdout="", stderr="")
-
-    monkeypatch.setattr(sync_module.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sync_module, "validate_copied_skill_tree", lambda target: (True, "")
+    )
 
     original_cwd = Path.cwd()
     try:
@@ -472,6 +558,73 @@ def test_copy_skill_syncs_malformed_frontmatter_when_validation_passes(
     assert reason == ""
     assert "name: external-source-a-broken-skill" in synced_content
     assert "description: 'invalid: colon-rich description'" in synced_content
+
+
+def test_copy_skill_preserves_marketplace_relative_path(tmp_path: Path, monkeypatch) -> None:
+    source = ExternalSource(
+        name="cannbot",
+        url="https://gitcode.com/cann/cannbot-skills",
+        sync_mode="marketplace",
+    )
+    skill_dir = tmp_path / "repo" / "ops" / "ascendc-code-review"
+    write_skill(skill_dir, "ascendc-code-review")
+    skill = Skill(
+        name="ascendc-code-review",
+        path=skill_dir,
+        source=source,
+        has_skill_md=True,
+        relative_path="ops/ascendc-code-review",
+    )
+
+    monkeypatch.setattr(
+        sync_module, "validate_copied_skill_tree", lambda target: (True, "")
+    )
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        success, reason = copy_skill(skill, "abc123")
+        synced_content = (
+            tmp_path
+            / "external"
+            / "cannbot"
+            / "ops"
+            / "ascendc-code-review"
+            / "SKILL.md"
+        ).read_text(encoding="utf-8")
+    finally:
+        os.chdir(original_cwd)
+
+    assert success is True
+    assert reason == ""
+    assert "name: external-cannbot-ops-ascendc-code-review" in synced_content
+
+
+def test_copy_skill_flat_mode_skips_nested_skill_directories(tmp_path: Path) -> None:
+    source = ExternalSource(name="source-a", url="https://example.com/a.git")
+    skill_dir = tmp_path / "repo" / "parent-skill"
+    write_skill(skill_dir, "parent-skill")
+    write_skill(skill_dir / "child-skill", "child-skill")
+    skill = Skill(name="parent-skill", path=skill_dir, source=source, has_skill_md=True)
+
+    original_cwd = Path.cwd()
+    try:
+        os.chdir(tmp_path)
+        success, reason = copy_skill(skill, "abc123")
+    finally:
+        os.chdir(original_cwd)
+
+    assert success is True
+    assert reason == ""
+    assert (tmp_path / "external" / "source-a" / "parent-skill" / "SKILL.md").exists()
+    assert not (
+        tmp_path
+        / "external"
+        / "source-a"
+        / "parent-skill"
+        / "child-skill"
+        / "SKILL.md"
+    ).exists()
 
 
 def test_update_marketplace_preserves_non_external_plugin_order(tmp_path: Path) -> None:
@@ -574,3 +727,138 @@ def test_update_marketplace_adds_category_library_when_creating_file(
     updated = json.loads(marketplace_path.read_text(encoding="utf-8"))
     assert "categoryLibrary" in updated
     assert "external" in updated["categoryLibrary"]["primaryCategories"]
+
+
+def test_update_marketplace_preserves_external_marketplace_bundles(
+    tmp_path: Path,
+) -> None:
+    marketplace_path = tmp_path / "marketplace.json"
+    source = ExternalSource(
+        name="cannbot",
+        url="https://gitcode.com/cann/cannbot-skills",
+        branch="master",
+        sync_mode="marketplace",
+    )
+    first_dir = tmp_path / "external" / "cannbot" / "ops" / "ascendc-code-review"
+    second_dir = (
+        tmp_path / "external" / "cannbot" / "ops" / "ascendc-docs-search"
+    )
+    write_skill(first_dir, "external-cannbot-ops-ascendc-code-review")
+    write_skill(second_dir, "external-cannbot-ops-ascendc-docs-search")
+    bundle = ExternalBundle(
+        name="ops-code-reviewer-skills",
+        source=source,
+        description="上游代码审查技能包",
+        skill_paths=[
+            "./external/cannbot/ops/ascendc-code-review",
+            "./external/cannbot/ops/ascendc-docs-search",
+        ],
+    )
+
+    update_marketplace(
+        [
+            (
+                Skill(
+                    "ascendc-code-review",
+                    first_dir,
+                    source,
+                    True,
+                    relative_path="ops/ascendc-code-review",
+                ),
+                "abc123",
+            ),
+            (
+                Skill(
+                    "ascendc-docs-search",
+                    second_dir,
+                    source,
+                    True,
+                    relative_path="ops/ascendc-docs-search",
+                ),
+                "abc123",
+            ),
+        ],
+        marketplace_path=str(marketplace_path),
+        external_bundles=[bundle],
+    )
+
+    plugins = json.loads(marketplace_path.read_text(encoding="utf-8"))["plugins"]
+    assert [plugin["name"] for plugin in plugins] == [
+        "external-cannbot-ops-code-reviewer-skills"
+    ]
+    assert plugins[0]["description"] == "上游代码审查技能包"
+    assert plugins[0]["skills"] == [
+        "./external/cannbot/ops/ascendc-code-review",
+        "./external/cannbot/ops/ascendc-docs-search",
+    ]
+
+
+def test_update_marketplace_filters_missing_external_bundle_paths(
+    tmp_path: Path,
+) -> None:
+    marketplace_path = tmp_path / "marketplace.json"
+    source = ExternalSource(
+        name="cannbot",
+        url="https://gitcode.com/cann/cannbot-skills",
+        sync_mode="marketplace",
+    )
+    existing_dir = tmp_path / "external" / "cannbot" / "ops" / "kept-skill"
+    write_skill(existing_dir, "external-cannbot-ops-kept-skill")
+    bundles = [
+        ExternalBundle(
+            name="partial-bundle",
+            source=source,
+            description="Partial bundle",
+            skill_paths=[
+                "./external/cannbot/ops/kept-skill",
+                "./external/cannbot/ops/missing-skill",
+            ],
+        ),
+        ExternalBundle(
+            name="empty-bundle",
+            source=source,
+            description="Empty bundle",
+            skill_paths=["./external/cannbot/ops/missing-only"],
+        ),
+    ]
+
+    update_marketplace(
+        [
+            (
+                Skill(
+                    "kept-skill",
+                    existing_dir,
+                    source,
+                    True,
+                    relative_path="ops/kept-skill",
+                ),
+                "abc123",
+            )
+        ],
+        marketplace_path=str(marketplace_path),
+        external_bundles=bundles,
+    )
+
+    plugins = json.loads(marketplace_path.read_text(encoding="utf-8"))["plugins"]
+    assert [plugin["name"] for plugin in plugins] == [
+        "external-cannbot-partial-bundle"
+    ]
+    assert plugins[0]["skills"] == ["./external/cannbot/ops/kept-skill"]
+
+
+def test_validate_config_rejects_unsafe_external_paths(tmp_path: Path) -> None:
+    config_path = tmp_path / "external-sources.yml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "sources:",
+                "  - name: bad-source",
+                "    url: https://example.com/repo.git",
+                "    skills_path: ../outside",
+                "    marketplace_path: /tmp/marketplace.json",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert validate_config(config_path) == 1


### PR DESCRIPTION
## 变更描述

### 变更类型
- [ ] 新增 Skill
- [ ] 更新现有 Skill
- [x] 修复问题
- [x] 其他（请说明）

### 涉及的 Skill
Skill 名称：外部同步 workflow / marketplace-aware sync

### 变更内容摘要
支持外部源通过 `sync_mode: marketplace` 按上游 `.claude-plugin/marketplace.json` 引用同步 skill，并保留上游 bundle 分组映射。
本 PR 只提交 workflow/脚本/测试/治理说明，不提交实际 sync 生成产物。

---

## 检查清单

### 治理规则检查
- [x] 已阅读 `docs/governance/skill-governance.md`
- [x] 已明确本次变更属于哪个功能域（external sync / workflow）
- [x] 已明确本次变更是 external / workflow 支持逻辑
- [x] 如为本地 skill，目录位于 `skills/<domain>/...`（不适用）
- [x] 如与其他 bundle 或 skill 容易混淆，已补充“怎么选”的边界说明

### SKILL.md 格式检查
- [x] `name` 字段与叶子目录名匹配，或符合 nested / `ai-for-science` 命名规则（未新增本地 SKILL.md）
- [x] `description` 字段不少于 20 个字符（未新增本地 SKILL.md）
- [x] frontmatter 格式正确（未新增本地 SKILL.md）
- [x] 包含 `description` 字段用于 Agent 匹配（未新增本地 SKILL.md）
- [x] 正文中无 `[TODO]` 或 `[TODO:xxx]` 占位符（未新增本地 SKILL.md）

### 内容完整性检查
- [x] 内部链接可正常访问（如 `references/xxx.md`）
- [x] 代码块已标注语言（如 ```bash、```python）
- [x] 表格格式正确（如有）

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`（不适用：未提交 sync 产物）
- [x] 已更新 `README.md` 中对应的导航 / 安装入口 / decision tree（不适用：未提交 sync 产物）
- [x] 如涉及开发目录导航，已同步更新 `skills/README.md` 或对应 `skills/<domain>/README.md`（不适用）
- [x] 如变更治理规则，已同步更新 `docs/governance/skill-governance.md`

---

## 测试说明

### 本地验证

```bash
python3 -m py_compile scripts/sync_external_skills.py scripts/sync_types.py scripts/validate_config.py scripts/validate_skills.py
python3 scripts/validate_config.py .github/external-sources.yml
python3 -m pytest tests/test_sync_external_skills.py -q
python3 scripts/validate_skills.py
git diff --check -- .github/external-sources.yml docs/governance/skill-governance.md scripts/sync_external_skills.py scripts/sync_types.py scripts/validate_config.py tests/test_sync_external_skills.py
```

结果：

```text
Config valid
24 passed
Validation PASSED
```

### 本地测试截图

不适用，本次为同步脚本 / workflow 支持逻辑变更。

### CI 检查
提交 PR 后将自动运行仓库 CI。

---

## 其他说明

- 未执行并提交实际外部 sync 结果。
- `cannbot` 外部源已加入配置，但实际内容会由后续 workflow 同步 PR 生成并审核。

### 关联 Issue
Fixes #

### 截图（如适用）
不适用。