### PR TITLE
feat: add npu-torchair-infer skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1009,6 +1009,19 @@
         "training",
         "base"
       ]
+    },
+    {
+      "name": "npu-torchair-infer",
+      "description": "Migrate any HuggingFace model to Ascend NPU torchair graph mode (torch.compile) and benchmark it for accuracy and performance against NPU eager and CPU eager. Use when running, compiling, or benchmarking HF models (vision, text, image-text encoders such as SigLIP2, DINOv3, ViT, CLIP, Qwen-VL, SAM) on Ascend 910B/CANN with torch_npu and torchair; when a torch.compile graph-mode run on NPU fails (Dynamo TorchRuntimeError, unsupported op, interpolate/contiguous errors); or when comparing torchair vs npu_eager vs cpu with cosine similarity, max abs diff, and p50/p95/p99 latency.",
+      "source": "./skills/inference/npu-torchair-infer",
+      "category": "inference",
+      "categories": [
+        "inference",
+        "leaf-skill",
+        "pytorch-npu",
+        "benchmarking",
+        "performance-analysis"
+      ]
     }
   ],
   "categoryLibrary": {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -337,7 +337,8 @@
         "./skills/inference/wan-ascend-adaptation",
         "./skills/inference/msmodelslim/msmodelslim-quant",
         "./skills/inference/vllm-ascend-server",
-        "./skills/inference/vllm-bench-serve"
+        "./skills/inference/vllm-bench-serve",
+        "./skills/inference/npu-torchair-infer"
       ],
       "category": "bundle",
       "categories": [

--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ cp -r awesome-ascend-skills/skills/ops/npu-op-benchmark your-project/.agents/ski
 | [diffusers-ascend-skills](skills/inference/diffusers-ascend/diffusers-ascend-pipeline/SKILL.md) | Diffusers 环境、权重准备与推理 |
 | [wan-ascend-adaptation](skills/inference/wan-ascend-adaptation/SKILL.md) | Wan 系列视频生成模型及相似扩散框架的昇腾适配指南 |
 | [migration-ascend-torchnpu-skills](skills/inference/migration-ascend-torchnpu-skills/SKILL.md) | 小模型基于torch_npu迁移至昇腾平台跑通，包含：环境搭建、迁移、报告生成 |
+| [npu-torchair-infer](skills/inference/npu-torchair-infer/SKILL.md) | HuggingFace 模型迁移到昇腾 NPU torchair 图模式（torch.compile），并与 NPU eager / CPU eager 做精度与性能对比 |
 
 ### 训练与通信
 

--- a/skills/inference/README.md
+++ b/skills/inference/README.md
@@ -13,6 +13,7 @@
 - [`diffusers-ascend/`](diffusers-ascend/)：Diffusers 环境、权重与推理
 - [`wan-ascend-adaptation/`](wan-ascend-adaptation/)：Wan 系列模型昇腾适配
 - [`migration-ascend-torchnpu-skills`](migration-ascend-torchnpu-skills/)：小模型基于torch_npu迁移至昇腾平台跑通，包含：环境搭建、迁移、报告生成
+- [`npu-torchair-infer/`](npu-torchair-infer/)：HuggingFace 模型迁移到昇腾 NPU torchair 图模式并做精度/性能对比
 
 推荐场景：
 

--- a/skills/inference/npu-torchair-infer/SKILL.md
+++ b/skills/inference/npu-torchair-infer/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: npu-torchair-infer
+description: Migrate any HuggingFace model to Ascend NPU torchair graph mode (torch.compile) and benchmark it for accuracy and performance against NPU eager and CPU eager. Use when running, compiling, or benchmarking HF models (vision, text, image-text encoders such as SigLIP2, DINOv3, ViT, CLIP, Qwen-VL, SAM) on Ascend 910B/CANN with torch_npu and torchair; when a torch.compile graph-mode run on NPU fails (Dynamo TorchRuntimeError, unsupported op, interpolate/contiguous errors); or when comparing torchair vs npu_eager vs cpu with cosine similarity, max abs diff, and p50/p95/p99 latency.
+---
+
+# NPU TorchAir Inference & Migration (主流程)
+
+## Overview
+
+Bring an arbitrary HuggingFace model up on **Ascend NPU torchair graph mode**,
+verify it numerically against CPU/NPU-eager, and measure its speedup. The bundled
+scripts are model-agnostic (config-driven inputs, recursive output comparison),
+so the same flow applies to the next model with only a changed
+`--model_name_or_path`.
+
+Bundled assets:
+- `scripts/torch_air_infer.py` — minimal single-backend inference + latency stats.
+- `scripts/benchmark.py` — 3-backend (torchair / npu_eager / cpu) accuracy + perf → JSON + Markdown.
+- `scripts/run_benchmark.sh` — generic driver: prepare model → sanity infer → benchmark.
+
+## The one rule you cannot break
+
+`torch_npu` MUST be imported **before** `torchair`, or graph mode does not engage.
+
+```python
+import torch
+import torch_npu        # before torchair
+import torchair
+config = torchair.CompilerConfig()
+npu_backend = torchair.get_npu_backend(compiler_config=config)
+model = torch.compile(model, backend=npu_backend, dynamic=False)
+```
+
+Details, version matrix, and CompilerConfig knobs: see `references/environment.md`.
+
+## Main flow (run in order)
+
+```bash
+source $ASCEND_HOME/ascend-toolkit/set_env.sh   # CANN runtime first
+export HF_ENDPOINT=https://hf-mirror.com         # China-friendly mirror
+
+# 0) Sanity on CPU (fast) — confirms inputs/outputs resolve for this model
+python scripts/torch_air_infer.py --model_name_or_path <path-or-id> --device cpu --backend eager
+
+# 1) NPU eager — confirms the model runs on NPU at all
+python scripts/torch_air_infer.py --model_name_or_path <path-or-id> --device npu --backend eager --dtype float16
+
+# 2) NPU torchair graph mode — the migration target
+python scripts/torch_air_infer.py --model_name_or_path <path-or-id> --device npu --backend torchair --dtype float16
+
+# 3) Full 3-backend accuracy + performance comparison (writes JSON + Markdown)
+python scripts/benchmark.py --model_name_or_path <path-or-id> \
+    --backends torchair,npu_eager,cpu --device npu \
+    --dtype float16 --batch_size 1 --warmup 10 --iterations 100 \
+    --output_dir benchmark_results/<model>
+
+# strict <1e-3 parity check (fits-in-memory models): re-run step 3 with --dtype float32
+```
+
+Or do steps 2+3 in one shot: `bash scripts/run_benchmark.sh <path-or-id> [out_subdir]`.
+
+## Decision tree
+
+```
+Step 0 (CPU) fails to build inputs?  → model needs a custom input builder (see references/methodology.md, BaseModelLoader.build_inputs).
+Step 1 (NPU eager) fails?            → environment problem: re-check import order + set_env.sh (references/environment.md).
+Step 2 (torchair) fails to compile?  → walk references/troubleshooting.md; fall back to npu_eager and keep going.
+Step 3 accuracy not within gate?     → compare torchair vs npu_eager first (references/methodology.md): same ⇒ fp16 rounding (PASS_COSINE); differ ⇒ graph bug.
+Weights gated / undownloadable?      → build a config-init random stand-in (references/methodology.md); valid for backend comparison, not task accuracy.
+```
+
+## Accuracy & performance gates (summary)
+
+- Golden = CPU fp32. Metrics: cosine sim, max abs diff, max rel err.
+- `PASS` = `max_abs_diff ≤ 1e-3` and `cosine ≥ 0.999`; `PASS_COSINE` = cosine passes (expected in fp16); else `FAIL`.
+- Perf: first iteration = compile cost (reported separately); steady p50/p95/p99 over ≥100 iters with `torch.npu.synchronize()` before each timer stop; report throughput + peak HBM.
+
+Full methodology, the model interface, gated-weights handling, and expected
+output: `references/methodology.md`.
+
+## References (load as needed)
+
+- `references/environment.md` — import order, CANN/torch_npu/torchair/transformers compatibility matrix, pre-flight checklist, CompilerConfig.
+- `references/troubleshooting.md` — compile-failure decision tree, known op failures (interpolate/contiguous), fallback order, bug localization.
+- `references/methodology.md` — `BaseModelLoader` interface, input synthesis, accuracy/perf methodology, config-init stand-ins, expected output.
+
+## Reuse checklist for the next model
+
+1. Step 0 on CPU — inputs/outputs resolve (fast).
+2. Step 1 NPU eager works.
+3. Step 2 torchair — compiles ⇒ done; else walk `references/troubleshooting.md`.
+4. Step 3 benchmark — gate on cosine (fp16) or `<1e-3` (fp32).
+5. If inputs could not be inferred, add a small `build_inputs` override (`references/methodology.md`).

--- a/skills/inference/npu-torchair-infer/references/environment.md
+++ b/skills/inference/npu-torchair-infer/references/environment.md
@@ -1,0 +1,68 @@
+# Environment, Import Order & Compatibility
+
+## Table of contents
+- The one non-negotiable rule: import order
+- Compatibility matrix
+- Pre-flight checklist
+- CompilerConfig knobs
+
+## The one non-negotiable rule: import order
+
+Graph mode silently degrades to eager (or errors) if `torch_npu` is not imported
+**before** `torchair`. `torch_npu` registers the `npu` device/backend that
+torchair depends on.
+
+```python
+import torch
+import torch_npu        # MUST come before torchair
+import torchair
+from torchair import patch_for_hcom
+patch_for_hcom()        # required only if the model has HCCL collectives; harmless otherwise
+
+config = torchair.CompilerConfig()
+# config.mode = "reduce-overhead"          # optional; guard with hasattr(config, "mode")
+npu_backend = torchair.get_npu_backend(compiler_config=config)
+model = torch.compile(model, backend=npu_backend, dynamic=False)
+```
+
+`dynamic=False` is recommended for fixed-shape encoders: it avoids dynamic-shape
+recompilation and produces the most stable graph. Use dynamic shapes only when
+the input shape genuinely varies per call.
+
+## Compatibility matrix
+
+`benchmark.py` records all of these automatically into `meta.env` of the JSON.
+Known-good baseline this skill was authored and validated against:
+
+| Component | Known-good | How to check |
+|---|---|---|
+| CANN toolkit | `8.5.1` | `cat $ASCEND_TOOLKIT_HOME/<arch>-linux/ascend_toolkit_install.info` |
+| Python | `3.11` | `python --version` |
+| torch | `2.9.0` (cpu wheel + torch_npu) | `python -c "import torch;print(torch.__version__)"` |
+| torch_npu | `2.9.0.post1` | `python -c "import torch_npu;print(torch_npu.__version__)"` |
+| torchair | bundled **inside** torch_npu (no standalone `__version__`) | `python -c "import torch_npu,torchair;print(hasattr(torchair,'get_npu_backend'))"` |
+| transformers | `4.57+` (must contain the model class) | `python -c "import transformers;print(transformers.__version__)"` |
+| device | 8× `Ascend910B3` healthy | `npu-smi info` |
+
+Hard rules:
+- torch and torch_npu **minor versions must match** (e.g. torch `2.9.x` ↔ torch_npu `2.9.x.postN`).
+- torchair ships with torch_npu — never `pip install torchair` separately.
+- `source $ASCEND_HOME/ascend-toolkit/set_env.sh` first, or torchair cannot find ATC/ACL and compile fails.
+
+## Pre-flight checklist
+
+- [ ] `source set_env.sh` done; `echo $ASCEND_TOOLKIT_HOME` is non-empty.
+- [ ] `import torch_npu` then `import torchair` both succeed (in that order).
+- [ ] `torch.npu.is_available()` is `True`; pick an NPU with enough free HBM (`npu-smi info`).
+- [ ] `transformers` actually contains the model class (`AutoModel` resolves it, or `hasattr(transformers, "<Class>")`).
+- [ ] Weights present locally; gated repos need an HF token, else build a config-init stand-in (see methodology.md) to validate mechanics.
+- [ ] dtype chosen: **fp16** for deployment-representative perf; **fp32** for strict (<1e-3) accuracy parity.
+
+## CompilerConfig knobs
+
+`torchair.CompilerConfig()` is the entry point. Common adjustments:
+- `config.mode` — optional execution mode (e.g. `"reduce-overhead"`); set only if `hasattr(config, "mode")`.
+- Keep defaults for the first attempt; only tune after a clean baseline compiles.
+
+On a busy/shared NPU (co-tenant workloads), expect higher latency variance and
+tighter free HBM — prefer fp16, small batch, and report p50.

--- a/skills/inference/npu-torchair-infer/references/methodology.md
+++ b/skills/inference/npu-torchair-infer/references/methodology.md
@@ -1,0 +1,106 @@
+# Accuracy & Performance Methodology + Model Interface
+
+## Table of contents
+- Pluggable model interface (BaseModelLoader)
+- Generic input synthesis (how the scripts infer inputs)
+- Accuracy methodology
+- Performance methodology
+- Gated / unavailable weights: config-init stand-ins
+- Expected output shapes
+
+## Pluggable model interface (BaseModelLoader)
+
+The scripts are **config-driven** so no model name is hard-coded. The contract an
+adapter must satisfy (the default implementation lives inline in the scripts):
+
+```python
+class BaseModelLoader:
+    def load_model(self, path, dtype, device) -> torch.nn.Module:
+        """eval()-ed module on `device` with `dtype` weights.
+        Default: transformers.AutoModel.from_pretrained(path, torch_dtype=dtype)."""
+
+    def build_inputs(self, config, batch_size, device, dtype) -> dict:
+        """kwargs consumed by model(**inputs). Default inspects config:
+          vision_config OR (image_size & patch_size) -> pixel_values [B,C,H,W]
+          text_config   OR vocab_size                -> input_ids/attention_mask [B,L]
+        Override only for exotic signatures (NaFlex pixel_attention_mask+spatial_shapes,
+        decoder_input_ids, etc.) or to feed real data via AutoProcessor."""
+
+    def extract_outputs(self, output) -> dict:
+        """Named float tensors to compare. Default recursively flattens
+        dict/list/ModelOutput; comparator auto-picks a primary key
+        (last_hidden_state > logits > pooler_output)."""
+```
+
+To support a new model you usually change **nothing**. Override `build_inputs`
+only when the forward needs inputs beyond `pixel_values` / `input_ids`.
+
+## Generic input synthesis (how the scripts infer inputs)
+
+`detect_modalities(config)` decides which dummy inputs to create:
+- `vision_config` present, or top-level `image_size` + `patch_size` ⇒ vision ⇒ `pixel_values`.
+- `text_config` present, or `vocab_size` on a non-vision model ⇒ text ⇒ `input_ids` + `attention_mask`.
+- image-text models (both sub-configs) get both.
+
+Inputs are seeded once; every backend `clone()`s + casts the *same* data so the
+comparison is apples-to-apples. If inference needs real data, swap the synthetic
+builder for `transformers.AutoProcessor`.
+
+## Accuracy methodology
+
+- CPU **fp32** output is the golden reference.
+- Metrics per output tensor: **cosine similarity**, **max absolute diff**, **max relative error**.
+- Recursively reduce dict/list outputs; compare a primary tensor (`last_hidden_state` / `logits` / `pooler_output`) plus every common key.
+- Status tiers:
+  - `PASS` — `max_abs_diff ≤ atol` (default `1e-3`) **and** `cosine ≥ threshold` (default `0.999`).
+  - `PASS_COSINE` — cosine passes but abs diff exceeds atol. **Expected for fp16**, and for embeddings with near-zero entries (relative error explodes while direction is identical).
+  - `FAIL` — neither.
+- Always add the **torchair-vs-npu_eager** cross-check (same device + dtype): it isolates *graph-vs-eager* divergence from *fp16-vs-fp32* rounding.
+
+Rule of thumb (validated on Ascend 910B3):
+- fp32 NPU↔CPU: `max_abs_diff ~1e-4..1e-3` ⇒ `PASS`.
+- fp16 NPU↔CPU: `~1e-2` abs but `cosine ≥ 0.9999` ⇒ `PASS_COSINE` (functionally equal). Projection heads / logits often still pass strict `<1e-3` in fp16.
+
+## Performance methodology
+
+- Warmup ≥ 10 iterations; **the first iteration is the compile/build cost** in graph mode — record it separately, never fold it into steady-state stats.
+- Time ≥ 100 steady iterations; **call `torch.npu.synchronize()` before stopping each timer** (NPU is async — without sync you measure launch latency, not compute).
+- Report `first_iter_ms`, `p50/p95/p99`, throughput (`batch×1000/p50`), and peak HBM (`torch.npu.max_memory_allocated()`).
+- On shared NPUs, latency variance rises — prefer p50 and note co-tenant load.
+
+## Gated / unavailable weights: config-init stand-ins
+
+When real weights are gated (no HF token) or undownloadable, build a
+**random-init** model from the real architecture/config:
+
+```python
+# generic (architecture inferred from a real config)
+from transformers import AutoConfig, AutoModel
+m = AutoModel.from_config(AutoConfig.from_pretrained(local_config_dir))
+
+# or an explicit architecture when only the class is known
+from transformers import DINOv3ViTModel, DINOv3ViTConfig
+m = DINOv3ViTModel(DINOv3ViTConfig())   # defaults == ViT-S/16
+m.save_pretrained(out_dir)
+```
+
+This is **valid** for CPU-vs-NPU / graph-vs-eager numerical comparison and for
+exercising the compile path (identical weights on both sides). It is **not**
+valid for downstream task accuracy. Always state in the report when a stand-in
+was used.
+
+## Expected output shapes
+
+```
+input[pixel_values  ] shape=(B, 3, H, W) dtype=<compute dtype>
+backend mode   : torchair(graph)
+output[last_hidden_state] shape=(B, N, D) dtype=<compute dtype>
+first iter (compile+run): <tens of seconds>      # one-time graph build
+steady latency  : p50=<small ms>  p95=...  p99=...
+throughput      : <samples/sec> @ p50
+```
+
+`benchmark_results.md` columns: backend · accuracy (cosine / max_abs_diff /
+rel_err / status) · perf (first_iter, p50/p95/p99, throughput, peak_mem). A
+failed graph compile appears as a `failed` row with the truncated error; other
+backends still complete.

--- a/skills/inference/npu-torchair-infer/references/troubleshooting.md
+++ b/skills/inference/npu-torchair-infer/references/troubleshooting.md
@@ -1,0 +1,74 @@
+# Troubleshooting Decision Tree
+
+## Table of contents
+- Decision tree
+- Known op-level failures (catalog)
+- Delivery fallback order
+- How to localize a graph-mode numerical bug
+
+## Decision tree
+
+```
+torch.compile(model, backend=npu_backend) FAILS or errors at runtime
+│
+├─ ImportError / the backend has no effect (runs but no graph)
+│    → fix import order (torch_npu BEFORE torchair); source set_env.sh;
+│      verify torch↔torch_npu minor versions match.
+│
+├─ Dynamo TorchRuntimeError during compile   (most common)
+│    │  Read the "from user code" frame — it names the offending op + the exact module line.
+│    ├─ "NPU contiguous operator only supported contiguous memory format"
+│    │   / upsample_bicubic2d / interpolate    (e.g. ViT interpolate_pos_encoding)
+│    │     → run at the model's NATIVE resolution so position-embedding interpolation is skipped,
+│    │       OR pass interpolate_pos_encoding=False,
+│    │       OR keep that submodule eager (wrap with torch.compiler.disable),
+│    │       OR fall back to npu_eager for this model.
+│    ├─ unsupported op / aten fallback
+│    │     → try a different config.mode; mark/report the op to CANN; use npu_eager meanwhile.
+│    └─ dynamic-shape recompiles / guard cache blowup
+│          → pass dynamic=False; fix input shapes; raise torch._dynamo.config.cache_size_limit.
+│
+├─ Compiles but OOM (HBM)
+│    → smaller batch; fp16 instead of fp32; pick a less-loaded NPU (npu-smi info);
+│      torch.npu.empty_cache() between runs.
+│
+└─ Compiles & runs but PRECISION looks wrong
+     → compare torchair vs npu_eager FIRST (same device + dtype):
+       ├─ they MATCH (cosine ≈ 1)  → divergence is fp16↔fp32 rounding, not a graph bug
+       │                              ⇒ accept PASS_COSINE (see methodology.md).
+       └─ they DIFFER               → genuine graph-mode numerical bug:
+              bisect by comparing intermediate hidden_states; disable fusion on the
+              suspect submodule; re-run that submodule in eager to localize the op;
+              file a minimal repro.
+```
+
+## Known op-level failures (catalog)
+
+| Symptom in traceback | Root cause | Fix |
+|---|---|---|
+| `NPU contiguous operator only supported contiguous memory format` after `upsample_bicubic2d` / `interpolate` | bicubic `interpolate` in ViT `interpolate_pos_encoding` decomposes to a `contiguous(memory_format=...)` NPU does not support in graph | run at native resolution / `interpolate_pos_encoding=False` / keep submodule eager / use npu_eager |
+| backend imported but graph never builds | wrong import order or missing `set_env.sh` | fix import order; source CANN env |
+| repeated recompilation, slow steady state | dynamic shapes | `dynamic=False`, fixed input shapes |
+
+Models using **RoPE** position embeddings (instead of interpolated learned
+position embeddings) typically avoid the interpolate/contiguous failure and
+compile cleanly.
+
+## Delivery fallback order
+
+Always degrade gracefully and **capture the full compile traceback** to an
+`.err.txt` so the failing op is recoverable later:
+
+```
+torchair graph  →  (on compile failure) npu_eager  →  (still off) cpu fp32
+```
+
+`benchmark.py` already implements this: a backend that fails is recorded as a
+`failed` row with the truncated error, and the other backends still run.
+
+## How to localize a graph-mode numerical bug
+
+1. Set `TORCHDYNAMO_VERBOSE=1` (and optionally `TORCH_LOGS="+dynamo"`) and re-run to get the internal stack.
+2. Add `output_hidden_states=True` and compare per-layer hidden states (torchair vs npu_eager) to find the first diverging layer.
+3. Wrap the suspect submodule with `torch.compiler.disable` to confirm it is the culprit.
+4. Reduce to a minimal module + input that reproduces, then report to the CANN/torch_npu team.

--- a/skills/inference/npu-torchair-infer/scripts/benchmark.py
+++ b/skills/inference/npu-torchair-infer/scripts/benchmark.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Accuracy + performance benchmark across three execution backends.
+
+Backends
+--------
+  * ``torchair``  : NPU graph mode (torch.compile + torchair.get_npu_backend)
+  * ``npu_eager`` : NPU single-op eager (no compile)
+  * ``cpu``       : CPU eager (fp32, used as the golden reference)
+
+For every backend we run the *same* seeded inputs, collect the model outputs,
+and report:
+  * accuracy vs the CPU golden output: cosine similarity, max abs diff, rel err
+  * a cross-check of torchair vs npu_eager (same device+dtype, should be tight)
+  * performance: first-iteration (compile) cost, steady p50/p95 latency,
+    throughput, and NPU peak memory.
+
+Results are written as ``benchmark_results.json`` and a Markdown table.
+
+Model-agnostic: nothing about SigLIP2 / DINOv3 (or any model) is hard-coded.
+"""
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import sys
+import time
+import traceback
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+# --- Mandatory import order: torch_npu BEFORE torchair ----------------------
+try:
+    import torch_npu  # noqa: F401
+    _HAS_TORCH_NPU = True
+except Exception:
+    torch_npu = None
+    _HAS_TORCH_NPU = False
+
+_HAS_TORCHAIR = False
+if _HAS_TORCH_NPU:
+    try:
+        import torchair  # noqa: F401  (after torch_npu)
+        from torchair import patch_for_hcom
+        _HAS_TORCHAIR = True
+    except Exception:
+        pass
+
+from transformers import AutoConfig, AutoModel
+
+
+# --------------------------------------------------------------------------- #
+# Generic helpers (shared design with torch_air_infer.py)
+# --------------------------------------------------------------------------- #
+def npu_available() -> bool:
+    return _HAS_TORCH_NPU and hasattr(torch, "npu") and torch.npu.is_available()
+
+
+DTYPES = {"float16": torch.float16, "bfloat16": torch.bfloat16, "float32": torch.float32}
+
+
+def _sub(config, name):
+    return getattr(config, name, None)
+
+
+def detect_modalities(config) -> Dict[str, Any]:
+    vision_cfg = _sub(config, "vision_config")
+    text_cfg = _sub(config, "text_config")
+    top_is_vision = _sub(config, "image_size") is not None and _sub(config, "patch_size") is not None
+    has_vision = vision_cfg is not None or top_is_vision
+    has_text = text_cfg is not None or (_sub(config, "vocab_size") is not None and not top_is_vision)
+    vsrc = vision_cfg if vision_cfg is not None else config
+    tsrc = text_cfg if text_cfg is not None else config
+    return {
+        "has_vision": has_vision, "has_text": has_text,
+        "image_size": getattr(vsrc, "image_size", 224) if has_vision else None,
+        "num_channels": getattr(vsrc, "num_channels", 3) if has_vision else None,
+        "vocab_size": getattr(tsrc, "vocab_size", 30522) if has_text else None,
+        "max_pos": getattr(tsrc, "max_position_embeddings", 64) if has_text else None,
+    }
+
+
+def build_cpu_inputs(config, batch_size, image_size, seq_len, seed) -> Dict[str, torch.Tensor]:
+    """Build one fixed (seeded) set of inputs on CPU. Backends clone+cast from this."""
+    torch.manual_seed(seed)
+    spec = detect_modalities(config)
+    inp: Dict[str, torch.Tensor] = {}
+    if spec["has_vision"]:
+        hw = image_size or spec["image_size"] or 224
+        c = spec["num_channels"] or 3
+        inp["pixel_values"] = torch.randn(batch_size, c, hw, hw, dtype=torch.float32)
+    if spec["has_text"]:
+        L = seq_len or min(spec["max_pos"] or 64, 64)
+        inp["input_ids"] = torch.randint(0, spec["vocab_size"] or 30522, (batch_size, L), dtype=torch.long)
+        inp["attention_mask"] = torch.ones(batch_size, L, dtype=torch.long)
+    if not inp:
+        raise ValueError("Could not infer inputs from config; a custom builder is needed.")
+    return inp
+
+
+def cast_inputs(cpu_inputs, device, float_dtype) -> Dict[str, torch.Tensor]:
+    out = {}
+    for k, v in cpu_inputs.items():
+        v = v.clone()
+        if v.is_floating_point():
+            v = v.to(float_dtype)
+        out[k] = v.to(device)
+    return out
+
+
+def flatten_float_tensors(obj: Any, prefix: str = "") -> Dict[str, torch.Tensor]:
+    out: Dict[str, torch.Tensor] = {}
+    if isinstance(obj, torch.Tensor):
+        if obj.is_floating_point():
+            out[prefix or "tensor"] = obj
+        return out
+    if isinstance(obj, dict) or hasattr(obj, "items"):
+        items = obj.items()
+    elif isinstance(obj, (list, tuple)):
+        items = [(str(i), v) for i, v in enumerate(obj)]
+    else:
+        return out
+    for k, v in items:
+        out.update(flatten_float_tensors(v, f"{prefix}.{k}" if prefix else str(k)))
+    return out
+
+
+def sync(device_kind):
+    if device_kind == "npu":
+        torch.npu.synchronize()
+
+
+# --------------------------------------------------------------------------- #
+# Accuracy metrics
+# --------------------------------------------------------------------------- #
+def compare(golden: torch.Tensor, cand: torch.Tensor) -> Dict[str, float]:
+    a = golden.detach().to("cpu", torch.float64).flatten()
+    b = cand.detach().to("cpu", torch.float64).flatten()
+    n = min(a.numel(), b.numel())
+    a, b = a[:n], b[:n]
+    diff = (a - b).abs()
+    denom = a.abs().clamp_min(1e-12)
+    cos = torch.nn.functional.cosine_similarity(a.unsqueeze(0), b.unsqueeze(0)).item()
+    return {
+        "cosine_sim": float(cos),
+        "max_abs_diff": float(diff.max().item()),
+        "mean_abs_diff": float(diff.mean().item()),
+        "max_rel_err": float((diff / denom).max().item()),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Per-backend run
+# --------------------------------------------------------------------------- #
+def load_model(path, float_dtype, device, trust_remote_code):
+    model = AutoModel.from_pretrained(path, trust_remote_code=trust_remote_code, torch_dtype=float_dtype)
+    return model.to(device).eval()
+
+
+def compile_torchair(model, compile_mode):
+    config = torchair.CompilerConfig()
+    if compile_mode and hasattr(config, "mode"):
+        config.mode = compile_mode
+    try:
+        patch_for_hcom()
+    except Exception:
+        pass
+    npu_backend = torchair.get_npu_backend(compiler_config=config)
+    return torch.compile(model, backend=npu_backend, dynamic=False)
+
+
+def percentiles(samples_ms: List[float]) -> Dict[str, float]:
+    s = sorted(samples_ms)
+    n = len(s)
+    pct = lambda p: s[min(n - 1, max(0, int(round((p / 100.0) * (n - 1)))))]  # noqa: E731
+    return {"p50": statistics.median(s), "p95": pct(95), "p99": pct(99),
+            "mean": statistics.fmean(s), "std": (statistics.pstdev(s) if n > 1 else 0.0),
+            "min": s[0], "max": s[-1]}
+
+
+def run_backend(name, args, cpu_inputs, config) -> Dict[str, Any]:
+    """Execute one backend end-to-end and return a result record."""
+    rec: Dict[str, Any] = {"backend": name, "status": "ok", "error": None}
+
+    if name == "cpu":
+        device_kind, device, float_dtype = "cpu", torch.device("cpu"), torch.float32
+    else:
+        if not npu_available():
+            rec.update(status="skipped", error="NPU not available")
+            return rec
+        device_kind = "npu"
+        device = torch.device(f"npu:{args.npu_id}")
+        float_dtype = DTYPES[args.dtype]
+        torch.npu.set_device(device)
+        torch.npu.reset_peak_memory_stats()
+
+    rec.update(device=str(device), dtype=str(float_dtype))
+
+    try:
+        model = load_model(args.model_name_or_path, float_dtype, device, args.trust_remote_code)
+        inputs = cast_inputs(cpu_inputs, device, float_dtype)
+
+        if name == "torchair":
+            if not _HAS_TORCHAIR:
+                raise RuntimeError("torchair not importable")
+            model = compile_torchair(model, args.compile_mode)
+
+        first_ms = None
+        with torch.inference_mode():
+            for i in range(max(args.warmup, 1)):
+                t0 = time.perf_counter()
+                out = model(**inputs)
+                sync(device_kind)
+                if i == 0:
+                    first_ms = (time.perf_counter() - t0) * 1000.0
+            samples = []
+            for _ in range(args.iterations):
+                t0 = time.perf_counter()
+                out = model(**inputs)
+                sync(device_kind)
+                samples.append((time.perf_counter() - t0) * 1000.0)
+
+        rec["outputs"] = {k: v.detach().to("cpu", torch.float32)
+                          for k, v in flatten_float_tensors(out).items()}
+        rec["perf"] = {"first_iter_ms": first_ms, **percentiles(samples),
+                       "iterations": len(samples),
+                       "throughput_sps": (args.batch_size * 1000.0) / statistics.median(samples)}
+        if device_kind == "npu":
+            rec["perf"]["peak_mem_mb"] = torch.npu.max_memory_allocated() / (1024 ** 2)
+    except Exception as exc:  # graph-mode compile failures land here -> graceful
+        rec.update(status="failed", error=f"{type(exc).__name__}: {exc}")
+        rec["traceback"] = traceback.format_exc()
+        print(f"[ERROR] backend={name} failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+    finally:
+        if device_kind == "npu":
+            try:
+                torch.npu.empty_cache()
+            except Exception:
+                pass
+    return rec
+
+
+# --------------------------------------------------------------------------- #
+# Reporting
+# --------------------------------------------------------------------------- #
+def pick_primary(keys: List[str]) -> Optional[str]:
+    for pref in ("last_hidden_state", "logits", "pooler_output", "image_embeds", "text_embeds"):
+        for k in keys:
+            if k.endswith(pref) or k == pref:
+                return k
+    return keys[0] if keys else None
+
+
+def build_accuracy(results, cosine_threshold, atol):
+    """Compare each NPU backend's outputs against the CPU golden."""
+    golden = next((r for r in results if r["backend"] == "cpu" and r["status"] == "ok"), None)
+    acc: Dict[str, Any] = {}
+    if golden is None or "outputs" not in golden:
+        return acc, None
+    gkeys = list(golden["outputs"].keys())
+    primary = pick_primary(gkeys)
+
+    for r in results:
+        if r["backend"] == "cpu" or r["status"] != "ok" or "outputs" not in r:
+            continue
+        per_out = {}
+        for k in gkeys:
+            if k in r["outputs"]:
+                m = compare(golden["outputs"][k], r["outputs"][k])
+                cos_ok = m["cosine_sim"] >= cosine_threshold
+                abs_ok = m["max_abs_diff"] <= atol
+                m["status"] = "PASS" if (cos_ok and abs_ok) else ("PASS_COSINE" if cos_ok else "FAIL")
+                per_out[k] = m
+        acc[r["backend"]] = {"primary_key": primary, "per_output": per_out}
+    return acc, primary
+
+
+def markdown_report(meta, results, accuracy, primary, cosine_threshold, atol) -> str:
+    L = []
+    L.append(f"# torchair migration benchmark: `{meta['model_name_or_path']}`\n")
+    L.append(f"_Generated {meta['timestamp']}_\n")
+    L.append("## Environment\n")
+    for k in ("python", "torch", "torch_npu", "torchair", "transformers", "cann", "npu_name", "device_count"):
+        L.append(f"- {k}: `{meta['env'].get(k)}`")
+    L.append(f"\n- batch_size: `{meta['batch_size']}`  dtype(NPU): `{meta['dtype']}`  "
+             f"warmup: `{meta['warmup']}`  iterations: `{meta['iterations']}`")
+    L.append(f"- accuracy gate: cosine ≥ `{cosine_threshold}`, max_abs_diff ≤ `{atol}`\n")
+
+    L.append("## Accuracy (vs CPU fp32 golden)\n")
+    if accuracy:
+        L.append(f"Primary output: `{primary}`\n")
+        L.append("| Backend | Output | cosine_sim | max_abs_diff | max_rel_err | Status |")
+        L.append("|---|---|---:|---:|---:|---|")
+        for bk, info in accuracy.items():
+            for okey, m in info["per_output"].items():
+                L.append(f"| {bk} | `{okey}` | {m['cosine_sim']:.6f} | {m['max_abs_diff']:.3e} | "
+                         f"{m['max_rel_err']:.3e} | {m['status']} |")
+    else:
+        L.append("_No CPU golden available; accuracy comparison skipped._")
+
+    L.append("\n## Performance (steady-state, warmup excluded)\n")
+    L.append("| Backend | Status | first_iter ms | p50 ms | p95 ms | p99 ms | throughput (sps) | peak_mem MB |")
+    L.append("|---|---|---:|---:|---:|---:|---:|---:|")
+    for r in results:
+        if r["status"] == "ok":
+            p = r["perf"]
+            L.append(f"| {r['backend']} | ok | {p['first_iter_ms']:.2f} | {p['p50']:.2f} | "
+                     f"{p['p95']:.2f} | {p['p99']:.2f} | {p['throughput_sps']:.2f} | "
+                     f"{p.get('peak_mem_mb', float('nan')):.1f} |")
+        else:
+            L.append(f"| {r['backend']} | **{r['status']}** | - | - | - | - | - | - | "
+                     f"<br>`{(r['error'] or '')[:160]}` |")
+
+    # Cross-check: torchair vs npu_eager (same device+dtype).
+    ta = next((r for r in results if r["backend"] == "torchair" and r["status"] == "ok"), None)
+    ne = next((r for r in results if r["backend"] == "npu_eager" and r["status"] == "ok"), None)
+    if ta and ne and primary in ta["outputs"] and primary in ne["outputs"]:
+        m = compare(ne["outputs"][primary], ta["outputs"][primary])
+        L.append("\n## Cross-check: torchair vs npu_eager (same dtype)\n")
+        L.append(f"- `{primary}`: cosine_sim=`{m['cosine_sim']:.6f}`  "
+                 f"max_abs_diff=`{m['max_abs_diff']:.3e}`  max_rel_err=`{m['max_rel_err']:.3e}`")
+        L.append(f"- gate (max_abs_diff ≤ {atol}): **{'PASS' if m['max_abs_diff'] <= atol else 'CHECK'}**")
+    return "\n".join(L) + "\n"
+
+
+def collect_env():
+    def ver(m):
+        try:
+            return __import__(m).__version__
+        except Exception:
+            return "n/a"
+    env = {
+        "python": platform.python_version(),
+        "platform": platform.platform(),
+        "torch": torch.__version__,
+        "torch_npu": getattr(torch_npu, "__version__", "n/a") if _HAS_TORCH_NPU else "n/a",
+        "torchair": "ships_with_torch_npu" if _HAS_TORCHAIR else "n/a",
+        "transformers": ver("transformers"),
+        "cann": os.environ.get("ASCEND_TOOLKIT_HOME", os.environ.get("ASCEND_HOME_PATH", "n/a")),
+        "device_count": torch.npu.device_count() if npu_available() else 0,
+        "npu_name": torch.npu.get_device_name(0) if npu_available() else "n/a",
+    }
+    return env
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Three-backend accuracy/performance benchmark for any HF model.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument("--model_name_or_path", required=True)
+    p.add_argument("--backends", default="torchair,npu_eager,cpu",
+                   help="Comma list from {torchair,npu_eager,cpu}.")
+    p.add_argument("--device", default="auto", choices=["auto", "npu", "cpu"],
+                   help="Accepted for CLI ergonomics; the actual device per run is "
+                        "implied by --backends (cpu vs npu_eager/torchair).")
+    p.add_argument("--npu_id", type=int, default=0)
+    p.add_argument("--dtype", default="float16", choices=list(DTYPES),
+                   help="Compute dtype for NPU backends (CPU golden is always fp32).")
+    p.add_argument("--batch_size", type=int, default=1)
+    p.add_argument("--image_size", type=int, default=None)
+    p.add_argument("--seq_len", type=int, default=None)
+    p.add_argument("--warmup", type=int, default=10)
+    p.add_argument("--iterations", type=int, default=100)
+    p.add_argument("--compile_mode", default=None)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--cosine_threshold", type=float, default=0.999)
+    p.add_argument("--atol", type=float, default=1e-3)
+    p.add_argument("--output_dir", default="benchmark_results")
+    p.add_argument("--trust_remote_code", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    os.makedirs(args.output_dir, exist_ok=True)
+
+    config = AutoConfig.from_pretrained(args.model_name_or_path, trust_remote_code=args.trust_remote_code)
+    cpu_inputs = build_cpu_inputs(config, args.batch_size, args.image_size, args.seq_len, args.seed)
+    print("Fixed inputs:", {k: tuple(v.shape) for k, v in cpu_inputs.items()})
+
+    results = []
+    for bk in backends:
+        print(f"\n>>> running backend: {bk}")
+        results.append(run_backend(bk, args, cpu_inputs, config))
+
+    accuracy, primary = build_accuracy(results, args.cosine_threshold, args.atol)
+
+    meta = {
+        "model_name_or_path": args.model_name_or_path,
+        "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
+        "batch_size": args.batch_size, "dtype": args.dtype,
+        "warmup": args.warmup, "iterations": args.iterations,
+        "env": collect_env(),
+    }
+
+    # JSON (outputs tensors stripped; keep metrics only).
+    json_results = []
+    for r in results:
+        j = {k: v for k, v in r.items() if k not in ("outputs", "traceback")}
+        json_results.append(j)
+    payload = {"meta": meta, "results": json_results, "accuracy": accuracy,
+               "primary_output": primary,
+               "gate": {"cosine_threshold": args.cosine_threshold, "atol": args.atol}}
+    json_path = os.path.join(args.output_dir, "benchmark_results.json")
+    with open(json_path, "w") as f:
+        json.dump(payload, f, indent=2)
+
+    md = markdown_report(meta, results, accuracy, primary, args.cosine_threshold, args.atol)
+    md_path = os.path.join(args.output_dir, "benchmark_results.md")
+    with open(md_path, "w") as f:
+        f.write(md)
+
+    print("\n" + md)
+    print(f"\n[OK] wrote {json_path}")
+    print(f"[OK] wrote {md_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/inference/npu-torchair-infer/scripts/run_benchmark.sh
+++ b/skills/inference/npu-torchair-infer/scripts/run_benchmark.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Generic torchair migration driver: prepare a model, run a graph-mode sanity
+# inference, then a 3-backend (torchair / npu_eager / cpu) accuracy+perf benchmark.
+#
+# Usage:
+#   bash run_benchmark.sh <model_name_or_path> [output_subdir]
+#
+# Examples:
+#   bash run_benchmark.sh google/siglip2-base-patch16-224
+#   bash run_benchmark.sh /data/models/my-vit  my-vit
+#
+# Tunables (env): NPU_ID DTYPE BATCH_SIZE WARMUP ITERS BACKENDS OUT_DIR
+#                 WEIGHT_MAX_TIME SKIP_DOWNLOAD HF_ENDPOINT TRUST_REMOTE_CODE
+set -uo pipefail
+
+MODEL="${1:?usage: run_benchmark.sh <model_name_or_path> [output_subdir]}"
+SUBDIR="${2:-$(basename "${MODEL}")}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+NPU_ID="${NPU_ID:-0}"
+DTYPE="${DTYPE:-float16}"                 # float16|bfloat16|float32 (NPU); CPU golden is fp32
+BATCH_SIZE="${BATCH_SIZE:-1}"
+WARMUP="${WARMUP:-10}"
+ITERS="${ITERS:-100}"
+BACKENDS="${BACKENDS:-torchair,npu_eager,cpu}"
+OUT_DIR="${OUT_DIR:-benchmark_results}"
+WEIGHT_MAX_TIME="${WEIGHT_MAX_TIME:-1800}"
+SKIP_DOWNLOAD="${SKIP_DOWNLOAD:-0}"
+export HF_ENDPOINT="${HF_ENDPOINT:-https://hf-mirror.com}"
+TRC=""; [ "${TRUST_REMOTE_CODE:-0}" = "1" ] && TRC="--trust_remote_code"
+
+# Source CANN runtime (provides ATC/ACL libs torchair needs).
+[ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ] && source /usr/local/Ascend/ascend-toolkit/set_env.sh
+log() { echo -e "\n\033[1;34m[run] $*\033[0m"; }
+
+# If MODEL is a repo id (not an existing dir) and download is allowed, fetch the
+# minimum files from the mirror. Only KEEP a weights file that downloaded fully
+# (curl exit 0) — a truncated partial would crash from_pretrained.
+resolve_model() {
+  local m="$1"
+  if [ -d "${m}" ]; then echo "${m}"; return 0; fi
+  if [ "${SKIP_DOWNLOAD}" = "1" ]; then echo "${m}"; return 0; fi  # let HF cache handle it
+  local dest="models/$(basename "${m}")"
+  if [ -s "${dest}/model.safetensors" ] || [ -s "${dest}/pytorch_model.bin" ]; then echo "${dest}"; return 0; fi
+  mkdir -p "${dest}"
+  local base="${HF_ENDPOINT}/${m}/resolve/main"
+  log "fetching ${m} from ${HF_ENDPOINT} (budget ${WEIGHT_MAX_TIME}s) ..." 1>&2
+  for f in config.json preprocessor_config.json tokenizer.json; do
+    curl -fsSL --retry 3 --connect-timeout 15 --max-time 120 -o "${dest}/${f}" "${base}/${f}" 2>/dev/null || true
+  done
+  for w in model.safetensors pytorch_model.bin; do
+    if curl -fSL --retry 3 --connect-timeout 15 --max-time "${WEIGHT_MAX_TIME}" \
+            -o "${dest}/${w}.part" "${base}/${w}" 2>/dev/null; then
+      mv "${dest}/${w}.part" "${dest}/${w}"; break
+    else rm -f "${dest}/${w}.part"; fi
+  done
+  if [ -s "${dest}/model.safetensors" ] || [ -s "${dest}/pytorch_model.bin" ]; then echo "${dest}"; else echo "${m}"; fi
+}
+
+MP="$(resolve_model "${MODEL}")"
+log "model resolved to: ${MP}"
+
+log "=== graph-mode sanity inference (torchair) ==="
+python "${HERE}/torch_air_infer.py" --model_name_or_path "${MP}" ${TRC} \
+  --device npu --npu_id "${NPU_ID}" --backend torchair --dtype "${DTYPE}" \
+  --batch_size "${BATCH_SIZE}" --warmup 3 --iterations 10
+
+log "=== 3-backend accuracy + performance benchmark ==="
+python "${HERE}/benchmark.py" --model_name_or_path "${MP}" ${TRC} \
+  --backends "${BACKENDS}" --device npu --npu_id "${NPU_ID}" --dtype "${DTYPE}" \
+  --batch_size "${BATCH_SIZE}" --warmup "${WARMUP}" --iterations "${ITERS}" \
+  --output_dir "${OUT_DIR}/${SUBDIR}"
+
+log "done. results: ${OUT_DIR}/${SUBDIR}/benchmark_results.{json,md}"

--- a/skills/inference/npu-torchair-infer/scripts/torch_air_infer.py
+++ b/skills/inference/npu-torchair-infer/scripts/torch_air_infer.py
@@ -57,11 +57,22 @@ def npu_available() -> bool:
 
 
 def resolve_device(requested: str, npu_id: int) -> Tuple[str, torch.device]:
-    """Map a --device request to (kind, torch.device). 'auto' prefers NPU."""
-    if requested in ("auto", "npu") and npu_available():
+    """Map a --device request to (kind, torch.device). 'auto' prefers NPU.
+
+    An explicit ``--device npu`` that cannot be satisfied is a hard error: silently
+    falling back to CPU would turn an intended CPU-vs-NPU comparison into a
+    meaningless CPU-vs-CPU one.
+    """
+    if requested == "npu":
+        if not npu_available():
+            raise RuntimeError(
+                "--device npu requested but NPU is unavailable "
+                f"(torch_npu imported: {_HAS_TORCH_NPU}). Refusing to fall back to CPU; "
+                "fix the environment (see references/environment.md) or pass --device cpu."
+            )
         return "npu", torch.device(f"npu:{npu_id}")
-    if requested == "npu" and not npu_available():
-        print("[WARN] NPU requested but unavailable; falling back to CPU.", file=sys.stderr)
+    if requested == "auto" and npu_available():
+        return "npu", torch.device(f"npu:{npu_id}")
     return "cpu", torch.device("cpu")
 
 

--- a/skills/inference/npu-torchair-infer/scripts/torch_air_infer.py
+++ b/skills/inference/npu-torchair-infer/scripts/torch_air_infer.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Minimal, model-agnostic torchair (NPU graph-mode) inference harness.
+
+This script loads *any* HuggingFace model from ``--model_name_or_path`` and runs
+it through one of three execution paths:
+
+  * ``torchair``  : NPU graph mode via ``torchair.get_npu_backend`` + ``torch.compile``
+  * ``eager``     : plain eager execution (NPU single-op, or CPU)
+
+It is intentionally free of any model-specific hard-coding. SigLIP2 / DINOv3 are
+only example validation cases; the same code path works for any encoder whose
+forward accepts ``pixel_values`` and/or ``input_ids``.
+
+IMPORTANT import order (graph mode only works if respected):
+    import torch
+    import torch_npu      # MUST be imported before torchair
+    import torchair
+"""
+
+import argparse
+import statistics
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+# --- Mandatory import order for NPU graph mode -----------------------------
+# torch_npu registers the 'npu' backend/device; torchair must come after it.
+try:
+    import torch_npu  # noqa: F401  (registers torch.npu)
+    _HAS_TORCH_NPU = True
+except Exception as exc:  # pragma: no cover - depends on host
+    torch_npu = None
+    _HAS_TORCH_NPU = False
+    _TORCH_NPU_IMPORT_ERROR = exc
+
+_HAS_TORCHAIR = False
+if _HAS_TORCH_NPU:
+    try:
+        import torchair  # noqa: F401  (MUST be imported after torch_npu)
+        from torchair import patch_for_hcom
+
+        _HAS_TORCHAIR = True
+    except Exception as exc:  # pragma: no cover
+        _TORCHAIR_IMPORT_ERROR = exc
+
+from transformers import AutoConfig, AutoModel
+
+
+# --------------------------------------------------------------------------- #
+# Device / dtype helpers
+# --------------------------------------------------------------------------- #
+def npu_available() -> bool:
+    return _HAS_TORCH_NPU and hasattr(torch, "npu") and torch.npu.is_available()
+
+
+def resolve_device(requested: str, npu_id: int) -> Tuple[str, torch.device]:
+    """Map a --device request to (kind, torch.device). 'auto' prefers NPU."""
+    if requested in ("auto", "npu") and npu_available():
+        return "npu", torch.device(f"npu:{npu_id}")
+    if requested == "npu" and not npu_available():
+        print("[WARN] NPU requested but unavailable; falling back to CPU.", file=sys.stderr)
+    return "cpu", torch.device("cpu")
+
+
+def resolve_dtype(name: Optional[str], device_kind: str) -> torch.dtype:
+    if name is not None:
+        return {"float16": torch.float16, "fp16": torch.float16,
+                "bfloat16": torch.bfloat16, "bf16": torch.bfloat16,
+                "float32": torch.float32, "fp32": torch.float32}[name]
+    # Sensible defaults: fp16 on NPU (matches deployment), fp32 on CPU.
+    return torch.float16 if device_kind == "npu" else torch.float32
+
+
+def sync(device_kind: str) -> None:
+    if device_kind == "npu":
+        torch.npu.synchronize()
+
+
+# --------------------------------------------------------------------------- #
+# Generic input synthesis (config-driven, no model-specific hard-coding)
+# --------------------------------------------------------------------------- #
+def _sub(config, name):
+    return getattr(config, name, None)
+
+
+def detect_modalities(config) -> Dict[str, Any]:
+    """Inspect an arbitrary HF config to decide which dummy inputs are needed."""
+    vision_cfg = _sub(config, "vision_config")
+    text_cfg = _sub(config, "text_config")
+
+    # Pure-vision models (e.g. ViT / DINOv3) expose image_size+patch_size at top.
+    top_is_vision = _sub(config, "image_size") is not None and _sub(config, "patch_size") is not None
+    has_vision = vision_cfg is not None or top_is_vision
+    # Text present if there is a text sub-config, or a vocab on a non-vision model.
+    has_text = text_cfg is not None or (_sub(config, "vocab_size") is not None and not top_is_vision)
+
+    vsrc = vision_cfg if vision_cfg is not None else config
+    tsrc = text_cfg if text_cfg is not None else config
+    return {
+        "has_vision": has_vision,
+        "has_text": has_text,
+        "image_size": getattr(vsrc, "image_size", 224) if has_vision else None,
+        "num_channels": getattr(vsrc, "num_channels", 3) if has_vision else None,
+        "vocab_size": getattr(tsrc, "vocab_size", 30522) if has_text else None,
+        "max_pos": getattr(tsrc, "max_position_embeddings", 64) if has_text else None,
+    }
+
+
+def build_inputs(config, batch_size: int, dtype: torch.dtype, device: torch.device,
+                 image_size: Optional[int], seq_len: Optional[int], seed: int) -> Dict[str, torch.Tensor]:
+    """Create a fixed (seeded) batch of dummy inputs appropriate for the model."""
+    torch.manual_seed(seed)
+    spec = detect_modalities(config)
+    inputs: Dict[str, torch.Tensor] = {}
+
+    if spec["has_vision"]:
+        hw = image_size or spec["image_size"] or 224
+        c = spec["num_channels"] or 3
+        inputs["pixel_values"] = torch.randn(batch_size, c, hw, hw, dtype=dtype)
+
+    if spec["has_text"]:
+        L = seq_len or min(spec["max_pos"] or 64, 64)
+        vocab = spec["vocab_size"] or 30522
+        inputs["input_ids"] = torch.randint(0, vocab, (batch_size, L), dtype=torch.long)
+        inputs["attention_mask"] = torch.ones(batch_size, L, dtype=torch.long)
+
+    if not inputs:
+        raise ValueError(
+            "Could not infer inputs from config (no vision_config/text_config/image_size/vocab_size). "
+            "This model likely needs a custom input builder.")
+
+    return {k: v.to(device) for k, v in inputs.items()}
+
+
+# --------------------------------------------------------------------------- #
+# Output handling
+# --------------------------------------------------------------------------- #
+def flatten_float_tensors(obj: Any, prefix: str = "") -> Dict[str, torch.Tensor]:
+    """Recursively collect floating-point tensors from a model output."""
+    out: Dict[str, torch.Tensor] = {}
+    if isinstance(obj, torch.Tensor):
+        if obj.is_floating_point():
+            out[prefix or "tensor"] = obj
+        return out
+    if isinstance(obj, dict):
+        items = obj.items()
+    elif hasattr(obj, "items"):  # ModelOutput behaves like a dict
+        items = obj.items()
+    elif isinstance(obj, (list, tuple)):
+        items = [(str(i), v) for i, v in enumerate(obj)]
+    else:
+        return out
+    for k, v in items:
+        out.update(flatten_float_tensors(v, f"{prefix}.{k}" if prefix else str(k)))
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Compilation
+# --------------------------------------------------------------------------- #
+def maybe_compile(model, backend: str, device_kind: str, compile_mode: Optional[str]):
+    """Wrap the model with the torchair NPU backend when requested."""
+    if backend != "torchair":
+        return model, "eager"
+    if device_kind != "npu":
+        print("[WARN] torchair backend only meaningful on NPU; using eager.", file=sys.stderr)
+        return model, "eager"
+    if not _HAS_TORCHAIR:
+        raise RuntimeError("torchair is not importable; cannot use graph mode.")
+
+    config = torchair.CompilerConfig()
+    if compile_mode:
+        # torchair exposes a 'mode' knob (e.g. 'reduce-overhead'); guard with hasattr.
+        if hasattr(config, "mode"):
+            config.mode = compile_mode
+        else:
+            print(f"[WARN] torchair CompilerConfig has no 'mode'; ignoring {compile_mode!r}.",
+                  file=sys.stderr)
+    # Required for models that contain HCCL collective ops; harmless otherwise.
+    try:
+        patch_for_hcom()
+    except Exception:
+        pass
+    npu_backend = torchair.get_npu_backend(compiler_config=config)
+    compiled = torch.compile(model, backend=npu_backend, dynamic=False)
+    return compiled, "torchair(graph)"
+
+
+# --------------------------------------------------------------------------- #
+# Timing
+# --------------------------------------------------------------------------- #
+def percentiles(samples_ms: List[float]) -> Dict[str, float]:
+    s = sorted(samples_ms)
+    n = len(s)
+
+    def pct(p):
+        if n == 1:
+            return s[0]
+        idx = min(n - 1, max(0, int(round((p / 100.0) * (n - 1)))))
+        return s[idx]
+
+    return {
+        "p50": statistics.median(s),
+        "p95": pct(95),
+        "p99": pct(99),
+        "mean": statistics.fmean(s),
+        "min": s[0],
+        "max": s[-1],
+    }
+
+
+def run(model, inputs, device_kind, warmup, iterations):
+    first_iter_ms = None
+    with torch.inference_mode():
+        # Warmup (first iteration captures compile/build overhead for graph mode).
+        for i in range(max(warmup, 1)):
+            t0 = time.perf_counter()
+            out = model(**inputs)
+            sync(device_kind)
+            if i == 0:
+                first_iter_ms = (time.perf_counter() - t0) * 1000.0
+
+        samples: List[float] = []
+        for _ in range(iterations):
+            t0 = time.perf_counter()
+            out = model(**inputs)
+            sync(device_kind)
+            samples.append((time.perf_counter() - t0) * 1000.0)
+    return out, first_iter_ms, samples
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Minimal generic torchair graph-mode inference for any HF model.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument("--model_name_or_path", required=True,
+                   help="HuggingFace repo id or local path (any vision / text / image-text encoder).")
+    p.add_argument("--device", default="auto", choices=["auto", "npu", "cpu"],
+                   help="Execution device. 'auto' prefers NPU and falls back to CPU.")
+    p.add_argument("--npu_id", type=int, default=0, help="NPU ordinal to bind to.")
+    p.add_argument("--backend", default="torchair", choices=["torchair", "eager"],
+                   help="'torchair' = NPU graph mode; 'eager' = single-op / CPU eager.")
+    p.add_argument("--dtype", default=None, choices=["float16", "bfloat16", "float32"],
+                   help="Compute dtype. Default: fp16 on NPU, fp32 on CPU.")
+    p.add_argument("--batch_size", type=int, default=1)
+    p.add_argument("--image_size", type=int, default=None,
+                   help="Override square image size; default taken from config.")
+    p.add_argument("--seq_len", type=int, default=None,
+                   help="Override text sequence length; default from config max_position_embeddings.")
+    p.add_argument("--warmup", type=int, default=3, help="Warmup iterations (>=3 recommended).")
+    p.add_argument("--iterations", type=int, default=20, help="Timed iterations.")
+    p.add_argument("--compile_mode", default=None,
+                   help="Optional torchair CompilerConfig.mode (e.g. 'reduce-overhead').")
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--trust_remote_code", action="store_true")
+    return p.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    device_kind, device = resolve_device(args.device, args.npu_id)
+    dtype = resolve_dtype(args.dtype, device_kind)
+
+    print("=" * 72)
+    print(f"model          : {args.model_name_or_path}")
+    print(f"device         : {device} ({device_kind})")
+    print(f"dtype          : {dtype}")
+    print(f"requested bk   : {args.backend}")
+    print(f"torch_npu      : {'yes' if _HAS_TORCH_NPU else 'NO'} | torchair: {'yes' if _HAS_TORCHAIR else 'NO'}")
+    print("=" * 72)
+
+    if device_kind == "npu":
+        torch.npu.set_device(device)
+
+    config = AutoConfig.from_pretrained(args.model_name_or_path, trust_remote_code=args.trust_remote_code)
+    model = AutoModel.from_pretrained(
+        args.model_name_or_path, trust_remote_code=args.trust_remote_code,
+        torch_dtype=dtype if device_kind == "npu" else torch.float32)
+    model = model.to(device).eval()
+
+    inputs = build_inputs(config, args.batch_size, dtype if device_kind == "npu" else torch.float32,
+                          device, args.image_size, args.seq_len, args.seed)
+    for k, v in inputs.items():
+        print(f"input[{k:14s}] shape={tuple(v.shape)} dtype={v.dtype}")
+
+    model, backend_mode = maybe_compile(model, args.backend, device_kind, args.compile_mode)
+    print(f"backend mode   : {backend_mode}")
+
+    out, first_ms, samples = run(model, inputs, device_kind, args.warmup, args.iterations)
+
+    for name, t in flatten_float_tensors(out).items():
+        print(f"output[{name}] shape={tuple(t.shape)} dtype={t.dtype}")
+
+    stats = percentiles(samples)
+    print("-" * 72)
+    print(f"first iter (compile+run): {first_ms:.2f} ms")
+    print(f"steady latency  : p50={stats['p50']:.2f}  p95={stats['p95']:.2f}  "
+          f"p99={stats['p99']:.2f}  mean={stats['mean']:.2f} ms  (n={len(samples)})")
+    thr = (args.batch_size * 1000.0) / stats["p50"] if stats["p50"] > 0 else float("nan")
+    print(f"throughput      : {thr:.2f} samples/sec @ p50")
+    print("=" * 72)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 变更描述

### 变更类型
- [x] 新增 Skill
- [ ] 更新现有 Skill
- [ ] 修复问题
- [ ] 其他（请说明）

### 涉及的 Skill
Skill 名称：npu-torchair-infer

### 变更内容摘要
新增 `npu-torchair-infer` skill：将任意 HuggingFace 模型迁移到昇腾 NPU torchair 图模式（torch.compile），并与 NPU eager / CPU eager 做精度（cosine、max abs diff、max rel err）与性能（p50/p95/p99、吞吐、峰值 HBM）对比。脚本与模型无关（config 驱动输入、递归输出比对），可复用到下一个模型。

---

## 检查清单

### 治理规则检查
- [x] 已阅读 `docs/governance/skill-governance.md`
- [x] 功能域：inference（模型迁移/推理 + 精度性能评测）
- [x] 类型：leaf（单一可独立触发的 skill）
- [x] 本地 skill 目录位于 `skills/inference/npu-torchair-infer/`
- [x] 与 `migration-ascend-torchnpu-skills` 的边界：后者面向通用 CPU/GPU→NPU 的 PyTorch 迁移与环境搭建；本 skill 专注 torchair 图模式（torch.compile）跑通 + 三后端（torchair / npu_eager / cpu）精度性能对比

### SKILL.md 格式检查
- [x] `name` 字段与叶子目录名一致（`npu-torchair-infer`）
- [x] `description` 不少于 20 个字符
- [x] frontmatter 以 `---` 开头和结尾
- [x] 包含 `description` 字段用于 Agent 匹配
- [x] 正文中无 `[TODO]` 占位符

### 内容完整性检查
- [x] 内部引用（`references/environment.md`、`references/methodology.md`、`references/troubleshooting.md`）均存在
- [x] 代码块已标注语言（bash / python）
- [x] 表格格式正确（如有）

### 仓库更新检查
- [x] 已添加到 `.claude-plugin/marketplace.json`
- [x] 已更新 `README.md` 推理导航表
- [x] 已更新 `skills/inference/README.md` 开发导航
- [ ] 未变更治理规则，无需更新 `docs/governance/skill-governance.md`

---

## 测试说明

### 1. 仓库校验

```bash
python3 scripts/validate_skills.py
```

结果：`Found 222 SKILL.md files ... Errors: 0`，`✅ Validation PASSED!`（`skills/inference/npu-torchair-infer/SKILL.md` 与 `marketplace.json` 均通过）。

### 2. Skill 功能实测（DINOv3 ViT-S/16）

- [x] 已在 AI Agent 中实测 skill 触发（"使用 skill `npu-torchair-infer` 把 dinov3 模型在 NPU 用 torchair 跑起来，给出精度、性能报告"）
- [x] 已验证 skill 内容正确加载并按主流程执行（Step 0 CPU sanity → Step 1 NPU eager → Step 2 torchair 图模式 → Step 3 三后端精度+性能对比 → 汇总报告，6/6 To-dos 全部完成）

**截图说明（共 3 张，见下方附件）：**

- **截图 1（Agent 执行过程）**：Agent 读取 skill 与 `references/`、`scripts/`，在 docker 容器 `model_migration_test` 内检查环境与模型权重（torch 2.9.0 / torch_npu 2.9.0.post1 / torchair available），按 6 步主流程跑通；模型权重从本地 `/root/.cache/modelscope/.../facebook/dinov3-vits16-pretrain-*` 加载（离线、无下载）。
<img width="496" height="937" alt="1" src="https://github.com/user-attachments/assets/ba69be95-4a31-4c1f-bf2f-a193bf22b3c3" />

- **截图 2（环境 + 精度报告）**：
<img width="489" height="725" alt="2" src="https://github.com/user-attachments/assets/36daf4ca-c989-43ed-a421-74e8eac1cf3e" />

- **截图 3（性能报告 + 产物）**：
<img width="493" height="542" alt="33" src="https://github.com/user-attachments/assets/96476b57-d7e1-48ed-a245-4ef791fdc590" />

---

## 其他说明

### 关联 Issue
Fixes #

Made with [Cursor](https://cursor.com)
